### PR TITLE
Translate the app via Qt Linguist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,11 @@ set(CMAKE_CXX_FLAGS_DEBUG "-fsanitize=address -fno-omit-frame-pointer -ggdb3 -O0
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -fno-omit-frame-pointer -DNDEBUG")
 
-find_package(Qt6 REQUIRED COMPONENTS Gui Widgets Core Concurrent) #OpenGLWidgets )
+find_package(Qt6 REQUIRED COMPONENTS Gui Widgets Core Concurrent LinguistTools) #OpenGLWidgets )
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(DJVU ddjvuapi)
+include(GNUInstallDirs)
 
 # SyncTeX
 find_path(SYNCTEX_INCLUDE_DIR
@@ -142,6 +143,7 @@ qt_add_resources(RESOURCES resources.qrc)
 # Add MuPDF headers
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/external/mupdf/include
+    ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
 target_sources(${PROJECT_NAME} PRIVATE ${RESOURCES})
@@ -155,6 +157,49 @@ else()
     target_link_libraries(${PROJECT_NAME} PRIVATE synctex)
 endif()
 
+
+
+# ------------------------------
+# Translations
+# ------------------------------
+set(TRANSLATION_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/Translations")
+file(GLOB TRANSLATION_FILES "${TRANSLATION_SRC_DIR}/*.ts")
+
+# Configure translationsdir.hpp
+set(TRANSLATIONS_DIR "${CMAKE_INSTALL_FULL_DATADIR}/locale")
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/TranslationsDir.hpp.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/TranslationsDir.hpp"
+    @ONLY
+)
+
+# Generate .qm files immediately without creating target dependencies
+qt_add_translations(
+    TARGETS ${PROJECT_NAME}            # Target that will use the .qm files
+    TS_FILES ${TRANSLATION_FILES}   # Explicit .ts files
+    QM_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/translations"
+    QM_FILES_OUTPUT_VARIABLE QM_FILES
+)
+
+# Install each .qm into locale/<lang>/LC_MESSAGES/
+foreach(qm_file ${QM_FILES})
+    get_filename_component(qm_name "${qm_file}" NAME)
+    string(REGEX REPLACE "\\.qm$" "" qm_name "${qm_name}")
+
+    string(REPLACE "lektra." "" lang "${qm_name}")
+
+    if(lang STREQUAL "${qm_name}")
+        set(lang "en")
+    endif()
+
+    install(
+        FILES "${qm_file}"
+        DESTINATION "${TRANSLATIONS_DIR}/${lang}/LC_MESSAGES"
+        RENAME "lektra.qm"
+    )
+endforeach()
+
+# -----
 
 
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/lektra_en.ts
+++ b/lektra_en.ts
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Run the update_translations CMake target to populate the source strings in this file.
+-->
+<!DOCTYPE TS>
+<TS version="2.1" language="en"/>

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -23,7 +23,7 @@ AboutDialog::AboutDialog(QWidget *parent)
       closeButton(new QPushButton("Close"))
 {
 
-    setWindowTitle("About");
+    setWindowTitle(tr("About"));
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint
                    & ~Qt::WindowMaximizeButtonHint);
 
@@ -82,11 +82,11 @@ AboutDialog::AboutDialog(QWidget *parent)
     connect(closeButton, &QPushButton::clicked, this, &QDialog::accept);
 
     QWidget *authorWidget = authorsSection();
-    m_tabWidget->addTab(authorWidget, "About");
+    m_tabWidget->addTab(authorWidget, tr("About"));
 
     QWidget *softwaresUsed = softwaresUsedSection();
-    m_tabWidget->addTab(softwaresUsed, "Libraries Used");
-    m_tabWidget->addTab(licenseTextEdit, "License");
+    m_tabWidget->addTab(softwaresUsed, tr("Libraries Used"));
+    m_tabWidget->addTab(licenseTextEdit, tr("License"));
     setWindowModality(Qt::NonModal);
 }
 
@@ -122,10 +122,10 @@ AboutDialog::authorsSection() noexcept
     QWidget *widget = new QWidget(this);
 
     QFormLayout *layout = new QFormLayout(widget);
-    layout->addRow("Version", new QLabel(APP_VERSION));
-    layout->addRow("Created by", new QLabel("Dheeraj Vittal Shenoy"));
+    layout->addRow(tr("Version"), new QLabel(APP_VERSION));
+    layout->addRow(tr("Created by"), new QLabel("Dheeraj Vittal Shenoy"));
     layout->addRow(
-        "Github", new QLabel("<a "
+        "GitHub", new QLabel("<a "
                              "href='https://codeberg.org/lektra/lektra'>https:/"
                              "/codeberg.org/lektra/lektra</a>"));
     widget->setLayout(layout);

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -10,7 +10,6 @@
 #include "Commands/TextAnnotationCommand.hpp"
 #include "Config.hpp"
 #include "GraphicsImageItem.hpp"
-#include "GraphicsPixmapItem.hpp"
 #include "GraphicsView.hpp"
 #include "LinkHint.hpp"
 #include "PropertiesWidget.hpp"
@@ -3994,10 +3993,11 @@ DocumentView::SaveRegionAsImage(QRectF area) noexcept
 
     QFileDialog fd(this);
     const QString fileName
-        = fd.getSaveFileName(this, "Save Image", "",
-                             "PNG Image (*.png), "
-                             "JPEG Image (*.jpg *.jpeg), "
-                             "BMP Image (*.bmp);; All Files (*)");
+        = fd.getSaveFileName(this, tr("Save Image"), "",
+                             tr("PNG Image") + " (*.png), " +
+                             tr("JPEG Image") + " (*.jpg *.jpeg), " +
+                             tr("BMP Image") + " (*.bmp);; All Files (*)"
+    );
     if (fileName.isEmpty())
         return;
     QString format;

--- a/src/EditLastPagesWidget.cpp
+++ b/src/EditLastPagesWidget.cpp
@@ -13,11 +13,11 @@ EditLastPagesWidget::EditLastPagesWidget(RecentFilesStore *store,
     else
         m_model->setEntries({});
 
-    m_autoremove_btn     = new QPushButton("Remove unfound files");
-    m_revert_changes_btn = new QPushButton("Revert Changes");
-    m_delete_row_btn     = new QPushButton("Delete row");
-    m_apply_btn          = new QPushButton("Apply");
-    m_close_btn          = new QPushButton("Close");
+    m_autoremove_btn     = new QPushButton(tr("Remove unfound files"));
+    m_revert_changes_btn = new QPushButton(tr("Revert Changes"));
+    m_delete_row_btn     = new QPushButton(tr("Delete row"));
+    m_apply_btn          = new QPushButton(tr("Apply"));
+    m_close_btn          = new QPushButton(tr("Close"));
 
     initConnections();
 
@@ -65,7 +65,7 @@ EditLastPagesWidget::initConnections() noexcept
     connect(m_apply_btn, &QPushButton::clicked, this, [&]()
     {
         auto confirm = QMessageBox::question(
-            this, "Apply Changes", "Do you want to apply the changes ?");
+            this, tr("Apply Changes"), tr("Do you want to apply the changes ?"));
         if (confirm == QMessageBox::Yes)
         {
             if (m_store)
@@ -73,8 +73,8 @@ EditLastPagesWidget::initConnections() noexcept
                 m_store->setEntries(m_model->entries());
                 if (!m_store->save())
                 {
-                    QMessageBox::warning(this, "Apply Changes",
-                                         "Failed to save recent files");
+                    QMessageBox::warning(this, tr("Apply Changes"),
+                                         tr("Failed to save recent files"));
                     return;
                 }
             }
@@ -118,12 +118,12 @@ EditLastPagesWidget::revertChanges() noexcept
 {
     if (!m_model->isDirty())
     {
-        QMessageBox::information(this, "Revert Changes",
-                                 "There are no changes to revert to");
+        QMessageBox::information(this, tr("Revert Changes"),
+                                 tr("There are no changes to revert to"));
         return;
     }
     auto confirm = QMessageBox::question(
-        this, "Revert Changes", "Do you really want to revert the changes ?");
+        this, tr("Revert Changes"), tr("Do you really want to revert the changes ?"));
     if (confirm == QMessageBox::Yes)
         m_model->revertAll();
 }

--- a/src/Lektra.cpp
+++ b/src/Lektra.cpp
@@ -20,12 +20,11 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QMimeData>
+#include <QObject>
 #include <QProcess>
 #include <QSplitter>
 #include <QStyleHints>
 #include <QWindow>
-#include <algorithm>
-#include <qobject.h>
 #include <variant>
 
 namespace
@@ -116,111 +115,111 @@ void
 Lektra::initMenubar() noexcept
 {
     // --- File Menu ---
-    QMenu *fileMenu = m_menuBar->addMenu("&File");
+    QMenu *fileMenu = m_menuBar->addMenu(tr("&File"));
 
     fileMenu->addAction(
-        QString("Open File\t%1").arg(m_config.shortcuts["file_open_tab"]), this,
+        tr("Open File\t%1").arg(m_config.shortcuts["file_open_tab"]), this,
         [&]() { OpenFileInNewTab(); });
 
-    fileMenu->addAction(QString("Open File In VSplit\t%1")
+    fileMenu->addAction(tr("Open File In VSplit\t%1")
                             .arg(m_config.shortcuts["file_open_vsplit"]),
                         this, [&]() { OpenFileVSplit(); });
 
-    fileMenu->addAction(QString("Open File In HSplit\t%1")
+    fileMenu->addAction(tr("Open File In HSplit\t%1")
                             .arg(m_config.shortcuts["file_open_hsplit"]),
                         this, [&]() { OpenFileHSplit(); });
 
-    m_recentFilesMenu = fileMenu->addMenu("Recent Files");
+    m_recentFilesMenu = fileMenu->addMenu(tr("Recent Files"));
 
     m_actionFileProperties
-        = fileMenu->addAction(QString("File Properties\t%1")
+        = fileMenu->addAction(tr("File Properties\t%1")
                                   .arg(m_config.shortcuts["file_properties"]),
                               this, &Lektra::FileProperties);
 
     m_actionOpenContainingFolder = fileMenu->addAction(
-        QString("Open Containing Folder\t%1")
+        tr("Open Containing Folder\t%1")
             .arg(m_config.shortcuts["open_containing_folder"]),
         this, &Lektra::OpenContainingFolder);
     m_actionOpenContainingFolder->setEnabled(false);
 
     m_actionSaveFile = fileMenu->addAction(
-        QString("Save File\t%1").arg(m_config.shortcuts["file_save"]), this,
+        tr("Save File\t%1").arg(m_config.shortcuts["file_save"]), this,
         &Lektra::SaveFile);
 
     m_actionSaveAsFile = fileMenu->addAction(
-        QString("Save As File\t%1").arg(m_config.shortcuts["file_save_as"]),
+        tr("Save As File\t%1").arg(m_config.shortcuts["file_save_as"]),
         this, &Lektra::SaveAsFile);
 
-    QMenu *sessionMenu = fileMenu->addMenu("Session");
+    QMenu *sessionMenu = fileMenu->addMenu(tr("Session"));
 
     m_actionSessionSave = sessionMenu->addAction(
-        QString("Save\t%1").arg(m_config.shortcuts["session_save"]), this,
+        tr("Save\t%1").arg(m_config.shortcuts["session_save"]), this,
         [&]() { SaveSession(); });
     m_actionSessionSaveAs = sessionMenu->addAction(
-        QString("Save As\t%1").arg(m_config.shortcuts["session_save_as"]), this,
+        tr("Save As\t%1").arg(m_config.shortcuts["session_save_as"]), this,
         [&]() { SaveAsSession(); });
     m_actionSessionLoad = sessionMenu->addAction(
-        QString("Load\t%1").arg(m_config.shortcuts["session_load"]), this,
+        tr("Load\t%1").arg(m_config.shortcuts["session_load"]), this,
         [&]() { LoadSession(); });
 
     m_actionSessionSaveAs->setEnabled(false);
 
     m_actionCloseFile = fileMenu->addAction(
-        QString("Close File\t%1").arg(m_config.shortcuts["file_close"]), this,
+        tr("Close File\t%1").arg(m_config.shortcuts["file_close"]), this,
         [this]() { Tab_close(); });
 
     fileMenu->addSeparator();
-    fileMenu->addAction("Quit", this, &QMainWindow::close);
+    fileMenu->addAction(tr("Quit"), this, &QMainWindow::close);
 
-    QMenu *editMenu = m_menuBar->addMenu("&Edit");
+    QMenu *editMenu = m_menuBar->addMenu(tr("&Edit"));
     m_actionUndo    = editMenu->addAction(
-        QString("Undo\t%1").arg(m_config.shortcuts["undo"]), this,
+        tr("Undo\t%1").arg(m_config.shortcuts["undo"]), this,
         &Lektra::Undo);
     m_actionRedo = editMenu->addAction(
-        QString("Redo\t%1").arg(m_config.shortcuts["redo"]), this,
+        tr("Redo\t%1").arg(m_config.shortcuts["redo"]), this,
         &Lektra::Redo);
     m_actionUndo->setEnabled(false);
     m_actionRedo->setEnabled(false);
     editMenu->addAction(
-        QString("Last Pages\t%1").arg(m_config.shortcuts["edit_last_pages"]),
+        tr("Last Pages\t%1").arg(m_config.shortcuts["edit_last_pages"]),
         this, &Lektra::editLastPages);
 
     // --- View Menu ---
-    m_viewMenu         = m_menuBar->addMenu("&View");
+    m_viewMenu         = m_menuBar->addMenu(tr("&View"));
     m_actionFullscreen = m_viewMenu->addAction(
-        QString("Fullscreen\t%1").arg(m_config.shortcuts["fullscreen"]), this,
+        tr("Fullscreen\t%1").arg(m_config.shortcuts["fullscreen"]), this,
         &Lektra::ToggleFullscreen);
     m_actionFullscreen->setCheckable(true);
     m_actionFullscreen->setChecked(m_config.window.fullscreen);
 
     m_actionZoomIn = m_viewMenu->addAction(
-        QString("Zoom In\t%1").arg(m_config.shortcuts["zoom_in"]), this,
+        tr("Zoom In\t%1").arg(m_config.shortcuts["zoom_in"]), this,
         &Lektra::ZoomIn);
     m_actionZoomOut = m_viewMenu->addAction(
-        QString("Zoom Out\t%1").arg(m_config.shortcuts["zoom_out"]), this,
+        tr("Zoom Out\t%1").arg(m_config.shortcuts["zoom_out"]), this,
         &Lektra::ZoomOut);
 
     m_viewMenu->addSeparator();
 
-    m_fitMenu = m_viewMenu->addMenu("Fit");
+    m_fitMenu = m_viewMenu->addMenu(tr("Fit"));
 
     m_actionFitWidth = m_fitMenu->addAction(
-        QString("Width\t%1").arg(m_config.shortcuts["fit_width"]), this,
+        tr("Width\t%1").arg(m_config.shortcuts["fit_width"]), this,
         &Lektra::Fit_width);
 
     m_actionFitHeight = m_fitMenu->addAction(
-        QString("Height\t%1").arg(m_config.shortcuts["fit_height"]), this,
+        tr("Height\t%1").arg(m_config.shortcuts["fit_height"]), this,
         &Lektra::Fit_height);
 
     m_actionFitWindow = m_fitMenu->addAction(
-        QString("Page\t%1").arg(m_config.shortcuts["fit_page"]), this,
+        tr("Page\t%1").arg(m_config.shortcuts["fit_page"]), this,
         &Lektra::Fit_page);
 
     m_fitMenu->addSeparator();
 
     // Auto Resize toggle (independent)
     m_actionAutoresize = m_viewMenu->addAction(
-        QString("Auto Fit\t%1").arg(m_config.shortcuts["fit_auto"]), this,
+        tr("Auto Fit\t%1").arg(m_config.shortcuts["fit_auto"]), this,
         &Lektra::ToggleAutoResize);
     m_actionAutoresize->setCheckable(true);
     m_actionAutoresize->setChecked(
@@ -229,26 +228,26 @@ Lektra::initMenubar() noexcept
     // --- Layout Menu ---
 
     m_viewMenu->addSeparator();
-    m_layoutMenu                    = m_viewMenu->addMenu("Layout");
+    m_layoutMenu                    = m_viewMenu->addMenu(tr("Layout"));
     QActionGroup *layoutActionGroup = new QActionGroup(this);
     layoutActionGroup->setExclusive(true);
 
     m_actionLayoutSingle = m_layoutMenu->addAction(
-        QString("Single Page\t%1").arg(m_config.shortcuts["layout_single"]),
+        tr("Single Page\t%1").arg(m_config.shortcuts["layout_single"]),
         this, [&]() { SetLayoutMode(DocumentView::LayoutMode::SINGLE); });
 
     m_actionLayoutLeftToRight = m_layoutMenu->addAction(
-        QString("Left to Right Page\t%1")
+        tr("Left to Right Page\t%1")
             .arg(m_config.shortcuts["layout_horizontal"]),
         this, [&]() { SetLayoutMode(DocumentView::LayoutMode::HORIZONTAL); });
 
     m_actionLayoutTopToBottom = m_layoutMenu->addAction(
-        QString("Top to Bottom Page\t%1")
+        tr("Top to Bottom Page\t%1")
             .arg(m_config.shortcuts["layout_vertical"]),
         this, [&]() { SetLayoutMode(DocumentView::LayoutMode::VERTICAL); });
 
     m_actionLayoutBook = m_layoutMenu->addAction(
-        QString("Book\t%1").arg(m_config.shortcuts["layout_book"]), this,
+        tr("Book\t%1").arg(m_config.shortcuts["layout_book"]), this,
         [&]() { SetLayoutMode(DocumentView::LayoutMode::BOOK); });
 
     layoutActionGroup->addAction(m_actionLayoutSingle);
@@ -273,29 +272,29 @@ Lektra::initMenubar() noexcept
     // --- Toggle Menu ---
 
     m_viewMenu->addSeparator();
-    m_toggleMenu = m_viewMenu->addMenu("Show/Hide");
+    m_toggleMenu = m_viewMenu->addMenu(tr("Show/Hide"));
 
 #ifdef ENABLE_LLM_SUPPORT
     m_actionToggleLLMWidget = m_toggleMenu->addAction(
-        QString("LLM Widget\t%1").arg(m_config.shortcuts["llm_widget"]), this,
+        tr("LLM Widget\t%1").arg(m_config.shortcuts["llm_widget"]), this,
         &Lektra::ToggleLLMWidget);
     m_actionToggleLLMWidget->setCheckable(true);
     m_actionToggleLLMWidget->setChecked(m_config.llm_widget.visible);
 #endif
 
     m_actionCommandPicker = m_toggleMenu->addAction(
-        QString("Command Picker\t%1").arg(m_config.shortcuts["command_picker"]),
+        tr("Command Picker\t%1").arg(m_config.shortcuts["command_picker"]),
         this, &Lektra::Show_command_picker);
 
     m_actionToggleOutline = m_toggleMenu->addAction(
-        QString("Outline\t%1").arg(m_config.shortcuts["picker_outline"]), this,
+        tr("Outline\t%1").arg(m_config.shortcuts["picker_outline"]), this,
         &Lektra::Show_outline);
     m_actionToggleOutline->setCheckable(true);
     m_actionToggleOutline->setChecked(m_outline_picker
                                       && !m_outline_picker->isHidden());
 
     m_actionToggleHighlightAnnotSearch = m_toggleMenu->addAction(
-        QString("Highlight Annotation Search\t%1")
+        tr("Highlight Annotation Search\t%1")
             .arg(m_config.shortcuts["picker_highlight_search"]),
         this, &Lektra::Show_highlight_search);
     m_actionToggleHighlightAnnotSearch->setCheckable(true);
@@ -303,75 +302,75 @@ Lektra::initMenubar() noexcept
         m_highlight_search_picker && !m_highlight_search_picker->isHidden());
 
     m_actionToggleMenubar = m_toggleMenu->addAction(
-        QString("Menubar\t%1").arg(m_config.shortcuts["menubar"]), this,
+        tr("Menubar\t%1").arg(m_config.shortcuts["menubar"]), this,
         &Lektra::ToggleMenubar);
     m_actionToggleMenubar->setCheckable(true);
     m_actionToggleMenubar->setChecked(!m_menuBar->isHidden());
 
     m_actionToggleTabBar = m_toggleMenu->addAction(
-        QString("Tabs\t%1").arg(m_config.shortcuts["tabs"]), this,
+        tr("Tabs\t%1").arg(m_config.shortcuts["tabs"]), this,
         &Lektra::ToggleTabBar);
     m_actionToggleTabBar->setCheckable(true);
     m_actionToggleTabBar->setChecked(!m_tab_widget->tabBar()->isHidden());
 
     m_actionTogglePanel = m_toggleMenu->addAction(
-        QString("Statusbar\t%1").arg(m_config.shortcuts["statusbar"]), this,
+        tr("Statusbar\t%1").arg(m_config.shortcuts["statusbar"]), this,
         &Lektra::TogglePanel);
     m_actionTogglePanel->setCheckable(true);
     m_actionTogglePanel->setChecked(!m_statusbar->isHidden());
 
     m_actionInvertColor = m_viewMenu->addAction(
-        QString("Invert Color\t%1").arg(m_config.shortcuts["invert_color"]),
+        tr("Invert Color\t%1").arg(m_config.shortcuts["invert_color"]),
         this, &Lektra::InvertColor);
     m_actionInvertColor->setCheckable(true);
     m_actionInvertColor->setChecked(m_config.behavior.invert_mode);
 
     // --- Tools Menu ---
 
-    QMenu *toolsMenu = m_menuBar->addMenu("Tools");
+    QMenu *toolsMenu = m_menuBar->addMenu(tr("Tools"));
 
-    m_modeMenu = toolsMenu->addMenu("Mode");
+    m_modeMenu = toolsMenu->addMenu(tr("Mode"));
 
     QActionGroup *modeActionGroup = new QActionGroup(this);
     modeActionGroup->setExclusive(true);
 
     m_actionRegionSelect = m_modeMenu->addAction(
-        QString("Region Selection\t%1")
+        tr("Region Selection\t%1")
             .arg(m_config.shortcuts["selection_mode_region"]),
         this, &Lektra::ToggleRegionSelect);
     m_actionRegionSelect->setCheckable(true);
     modeActionGroup->addAction(m_actionRegionSelect);
 
     m_actionTextSelect = m_modeMenu->addAction(
-        QString("Text Selection\t%1")
+        tr("Text Selection\t%1")
             .arg(m_config.shortcuts["selection_mode_text"]),
         this, &Lektra::ToggleTextSelection);
     m_actionTextSelect->setCheckable(true);
     modeActionGroup->addAction(m_actionTextSelect);
 
     m_actionTextHighlight = m_modeMenu->addAction(
-        QString("Text Highlight\t%1")
+        tr("Text Highlight\t%1")
             .arg(m_config.shortcuts["annot_highlight_mode"]),
         this, &Lektra::ToggleTextHighlight);
     m_actionTextHighlight->setCheckable(true);
     modeActionGroup->addAction(m_actionTextHighlight);
 
     m_actionAnnotRect
-        = m_modeMenu->addAction(QString("Annotate Rectangle\t%1")
+        = m_modeMenu->addAction(tr("Annotate Rectangle\t%1")
                                     .arg(m_config.shortcuts["annot_rect_mode"]),
                                 this, &Lektra::ToggleAnnotRect);
     m_actionAnnotRect->setCheckable(true);
     modeActionGroup->addAction(m_actionAnnotRect);
 
     m_actionAnnotEdit
-        = m_modeMenu->addAction(QString("Edit Annotations\t%1")
+        = m_modeMenu->addAction(tr("Edit Annotations\t%1")
                                     .arg(m_config.shortcuts["annot_edit_mode"]),
                                 this, &Lektra::ToggleAnnotSelect);
     m_actionAnnotEdit->setCheckable(true);
     modeActionGroup->addAction(m_actionAnnotEdit);
 
     m_actionAnnotPopup = m_modeMenu->addAction(
-        QString("Annotate Popup\t%1")
+        tr("Annotate Popup\t%1")
             .arg(m_config.shortcuts["annot_popup_mode"]),
         this, &Lektra::ToggleAnnotPopup);
     m_actionAnnotPopup->setCheckable(true);
@@ -379,14 +378,14 @@ Lektra::initMenubar() noexcept
 
     // TODO: Store visual line mode state in config
     m_actionVisualLineMode = m_modeMenu->addAction(
-        QString("Visual Line Mode\t%1")
+        tr("Visual Line Mode\t%1")
             .arg(m_config.shortcuts["visual_line_mode"]),
         this, &Lektra::Toggle_visual_line_mode);
     m_actionVisualLineMode->setCheckable(true);
     modeActionGroup->addAction(m_actionVisualLineMode);
 
     m_actionNoneMode = m_modeMenu->addAction(
-        QString("None\t%1").arg(m_config.shortcuts["none_mode"]), this,
+        tr("None\t%1").arg(m_config.shortcuts["none_mode"]), this,
         &Lektra::Toggle_none_mode);
     m_actionNoneMode->setCheckable(true);
     modeActionGroup->addAction(m_actionNoneMode);
@@ -425,71 +424,71 @@ Lektra::initMenubar() noexcept
     }
 
     m_actionEncrypt = toolsMenu->addAction(
-        QString("Encrypt Document\t%1").arg(m_config.shortcuts["file_encrypt"]),
+        tr("Encrypt Document\t%1").arg(m_config.shortcuts["file_encrypt"]),
         this, &Lektra::EncryptDocument);
     m_actionEncrypt->setEnabled(false);
 
     m_actionDecrypt = toolsMenu->addAction(
-        QString("Decrypt Document\t%1").arg(m_config.shortcuts["file_decrypt"]),
+        tr("Decrypt Document\t%1").arg(m_config.shortcuts["file_decrypt"]),
         this, &Lektra::DecryptDocument);
     m_actionDecrypt->setEnabled(false);
 
     // --- Navigation Menu ---
-    m_navMenu = m_menuBar->addMenu("&Navigation");
+    m_navMenu = m_menuBar->addMenu(tr("&Navigation"));
 
     m_navMenu->addAction(
-        QString("StartPage\t%1").arg(m_config.shortcuts["show_startup_widget"]),
+        tr("StartPage\t%1").arg(m_config.shortcuts["show_startup_widget"]),
         this, &Lektra::showStartupWidget);
 
     m_actionGotoPage = m_navMenu->addAction(
-        QString("Goto Page\t%1").arg(m_config.shortcuts["page_goto"]), this,
+        tr("Goto Page\t%1").arg(m_config.shortcuts["page_goto"]), this,
         &Lektra::Goto_page);
 
     m_actionFirstPage = m_navMenu->addAction(
-        QString("First Page\t%1").arg(m_config.shortcuts["page_first"]), this,
+        tr("First Page\t%1").arg(m_config.shortcuts["page_first"]), this,
         &Lektra::FirstPage);
 
     m_actionPrevPage = m_navMenu->addAction(
-        QString("Previous Page\t%1").arg(m_config.shortcuts["page_prev"]), this,
+        tr("Previous Page\t%1").arg(m_config.shortcuts["page_prev"]), this,
         &Lektra::PrevPage);
 
     m_actionNextPage = m_navMenu->addAction(
-        QString("Next Page\t%1").arg(m_config.shortcuts["page_next"]), this,
+        tr("Next Page\t%1").arg(m_config.shortcuts["page_next"]), this,
         &Lektra::NextPage);
     m_actionLastPage = m_navMenu->addAction(
-        QString("Last Page\t%1").arg(m_config.shortcuts["page_last"]), this,
+        tr("Last Page\t%1").arg(m_config.shortcuts["page_last"]), this,
         &Lektra::LastPage);
 
     m_actionPrevLocation
-        = m_navMenu->addAction(QString("Previous Location\t%1")
+        = m_navMenu->addAction(tr("Previous Location\t%1")
                                    .arg(m_config.shortcuts["location_prev"]),
                                this, &Lektra::GoBackHistory);
     m_actionNextLocation = m_navMenu->addAction(
-        QString("Next Location\t%1").arg(m_config.shortcuts["location_next"]),
+        tr("Next Location\t%1").arg(m_config.shortcuts["location_next"]),
         this, &Lektra::GoForwardHistory);
 
-    QMenu *markMenu = m_navMenu->addMenu("Marks");
+    QMenu *markMenu = m_navMenu->addMenu(tr("Marks"));
 
     m_actionSetMark = markMenu->addAction(
-        QString("Set Mar\t%1").arg(m_config.shortcuts["set_mark"]), this,
+        tr("Set Mark\t%1").arg(m_config.shortcuts["set_mark"]), this,
         &Lektra::SetMark);
 
     m_actionGotoMark = markMenu->addAction(
-        QString("Goto Mark\t%1").arg(m_config.shortcuts["goto_mark"]), this,
+        tr("Goto Mark\t%1").arg(m_config.shortcuts["goto_mark"]), this,
         &Lektra::GotoMark);
 
     m_actionDeleteMark = markMenu->addAction(
-        QString("Delete Mark\t%1").arg(m_config.shortcuts["delete_mark"]), this,
+        tr("Delete Mark\t%1").arg(m_config.shortcuts["delete_mark"]), this,
         &Lektra::DeleteMark);
 
     /* Help Menu */
-    QMenu *helpMenu = m_menuBar->addMenu("&Help");
+    QMenu *helpMenu = m_menuBar->addMenu(tr("&Help"));
     m_actionAbout   = helpMenu->addAction(
-        QString("About\t%1").arg(m_config.shortcuts["show_about"]), this,
+        tr("About\t%1").arg(m_config.shortcuts["show_about"]), this,
         &Lektra::ShowAbout);
 
     m_actionShowTutorialFile = helpMenu->addAction(
-        QString("Open Tutorial File\t%1")
+        tr("Open Tutorial File\t%1")
             .arg(m_config.shortcuts["show_tutorial_file"]),
         this, &Lektra::showTutorialFile);
 }
@@ -533,7 +532,7 @@ Lektra::initConfig() noexcept
     {
         QMessageBox::critical(
             this, "Error in configuration file",
-            QString("There are one or more error(s) in your config "
+            tr("There are one or more error(s) in your config "
                     "file:\n%1\n\nLoading default config.")
                 .arg(e.what()));
         return;
@@ -1119,7 +1118,7 @@ Lektra::warnShortcutConflicts() noexcept
             keyDisplay = it.key();
 
         const QString actions = it.value().join(", ");
-        conflicts.append(QString("%1 -> %2").arg(keyDisplay, actions));
+        conflicts.append(tr("%1 -> %2").arg(keyDisplay, actions));
     }
 
     if (conflicts.isEmpty())
@@ -1129,11 +1128,11 @@ Lektra::warnShortcutConflicts() noexcept
     QString message;
     if (conflicts.size() <= maxItems)
     {
-        message = QString("Shortcut conflict(s): %1").arg(conflicts.join("; "));
+        message = tr("Shortcut conflict(s): %1").arg(conflicts.join("; "));
     }
     else
     {
-        message = QString("Shortcut conflict(s): %1; and %2 more")
+        message = tr("Shortcut conflict(s): %1; and %2 more")
                       .arg(conflicts.mid(0, maxItems).join("; "))
                       .arg(conflicts.size() - maxItems);
     }
@@ -1176,7 +1175,7 @@ Lektra::initGui() noexcept
         const auto it = m_actionMap.find(action);
         if (it == m_actionMap.end())
         {
-            m_message_bar->showMessage(QStringLiteral("LLM: Unknown action"));
+            m_message_bar->showMessage(tr("LLM: Unknown action"));
             return;
         }
         it.value()(args);
@@ -1621,7 +1620,7 @@ Lektra::Goto_page() noexcept
 
     bool ok;
     int pageno = QInputDialog::getInt(
-        this, "Goto Page", QString("Enter page number (1 to %1)").arg(total),
+        this, "Goto Page", tr("Enter page number (1 to %1)").arg(total),
         m_doc->pageNo() + 1, 0, m_doc->numPages(), 1, &ok);
 
     if (!ok)
@@ -1630,7 +1629,7 @@ Lektra::Goto_page() noexcept
     if (pageno <= 0 || pageno > total)
     {
         QMessageBox::critical(this, "Goto Page",
-                              QString("Page %1 is out of range").arg(pageno));
+                              tr("Page %1 is out of range").arg(pageno));
         return;
     }
 
@@ -1820,7 +1819,7 @@ Lektra::OpenFileInContainer(DocumentContainer *container,
     {
         QFileDialog dialog(this);
         dialog.setFileMode(QFileDialog::ExistingFile);
-        dialog.setNameFilter(tr("PDF Files (*.pdf);;All Files (*)"));
+        dialog.setNameFilter(tr("PDF Files") + " " + "(*.pdf)" + ";;" + tr("All Files") + " " + "(*)");
         if (dialog.exec())
         {
             const QStringList selected = dialog.selectedFiles();
@@ -1991,7 +1990,7 @@ Lektra::OpenFileInNewTab(const QString &filename,
         // Show file picker
         QFileDialog dialog(this);
         dialog.setFileMode(QFileDialog::ExistingFile);
-        dialog.setNameFilter(tr("PDF Files (*.pdf);;All Files (*)"));
+        dialog.setNameFilter(tr("PDF Files") + " " + "(*.pdf)" + ";;" + tr("All Files") + " " + "(*)");
 
         if (dialog.exec())
         {
@@ -2109,7 +2108,7 @@ Lektra::openFileSplitHelper(const QString &filename,
         // Show file picker
         QFileDialog dialog(this);
         dialog.setFileMode(QFileDialog::ExistingFile);
-        dialog.setNameFilter(tr("PDF Files (*.pdf);;All Files (*)"));
+        dialog.setNameFilter(tr("PDF Files") + " " + "(*.pdf)" + ";;" + tr("All Files") + " " + "(*)");
 
         if (dialog.exec())
         {
@@ -2200,7 +2199,7 @@ Lektra::OpenFileInNewWindow(const QString &filePath,
     {
         QStringList files;
         files = QFileDialog::getOpenFileNames(
-            this, "Open File", "", "PDF Files (*.pdf);; All Files (*)");
+            this, tr("Open File"), "", tr("PDF Files") + " " + "(*.pdf)" + ";;" + tr("All Files") + " " + "(*)");
         if (files.empty())
             return false;
         else
@@ -2237,7 +2236,7 @@ Lektra::OpenFileInNewWindow(const QString &filePath,
     if (!QFile::exists(fp))
     {
         QMessageBox::warning(this, "Open File",
-                             QString("Unable to find %1").arg(fp));
+                             tr("Unable to find %1").arg(fp));
         return false;
     }
 
@@ -2782,7 +2781,7 @@ Lektra::closeEvent(QCloseEvent *e)
             {
                 int ret = QMessageBox::warning(
                     this, "Unsaved Changes",
-                    QString("File %1 has unsaved changes. Do you want to save "
+                    tr("File %1 has unsaved changes. Do you want to save "
                             "them?")
                         .arg(m_tab_widget->tabText(i)),
                     QMessageBox::Save | QMessageBox::Discard
@@ -2805,7 +2804,7 @@ Lektra::closeEvent(QCloseEvent *e)
     if (m_config.behavior.confirm_on_quit)
     {
         int ret = QMessageBox::question(
-            this, "Confirm Quit", "Are you sure you want to quit Lektra?",
+            this, tr("Confirm Quit"), tr("Are you sure you want to quit Lektra?"),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
         if (ret == QMessageBox::No)
@@ -2922,19 +2921,19 @@ Lektra::handleTabContextMenu(QObject *object, QEvent *event) noexcept
         return true;
 
     QMenu menu;
-    menu.addAction("Open Location", this,
+    menu.addAction(tr("Open Location"), this,
                    [this, index]() { openInExplorerForIndex(index); });
-    menu.addAction("File Properties", this,
+    menu.addAction(tr("File Properties"), this,
                    [this, index]() { filePropertiesForIndex(index); });
     menu.addSeparator();
-    menu.addAction("Move Tab to New Window", this, [this, index]()
+    menu.addAction(tr("Move Tab to New Window"), this, [this, index]()
     {
         TabBar::TabData data;
         handleTabDataRequested(index, &data);
         if (!data.filePath.isEmpty())
             handleTabDetachedToNewWindow(index, data);
     });
-    menu.addAction("Close Tab", this,
+    menu.addAction(tr("Close Tab"), this,
                    [this, index]() { m_tab_widget->tabCloseRequested(index); });
 
     menu.exec(contextEvent->globalPos());
@@ -3285,7 +3284,7 @@ Lektra::LoadSession(QString sessionName) noexcept
     QStringList existingSessions = getSessionFiles();
     if (existingSessions.empty())
     {
-        QMessageBox::information(this, "Load Session", "No sessions found");
+        QMessageBox::information(this, tr("Load Session"), tr("No sessions found"));
         return;
     }
 
@@ -3293,8 +3292,8 @@ Lektra::LoadSession(QString sessionName) noexcept
     {
         bool ok;
         sessionName = QInputDialog::getItem(
-            this, "Load Session",
-            "Session to load (existing sessions are listed): ",
+            this, tr("Load Session"),
+            tr("Session to load (existing sessions are listed): "),
             existingSessions, 0, true, &ok);
     }
 
@@ -3307,20 +3306,20 @@ Lektra::LoadSession(QString sessionName) noexcept
 
         if (err.error != QJsonParseError::NoError)
         {
-            QMessageBox::critical(this, "Session File Parse Error",
+            QMessageBox::critical(this, tr("Session File Parse Error"),
                                   err.errorString());
 #ifndef NDEBUG
-            qDebug() << "JSON parse error:" << err.errorString();
+            qDebug() << tr("JSON parse error:") << err.errorString();
 #endif
             return;
         }
 
         if (!doc.isArray())
         {
-            QMessageBox::critical(this, "Session File Parse Error",
-                                  "Session file root is not an array");
+            QMessageBox::critical(this, tr("Session File Parse Error"),
+                                  tr("Session file root is not an array"));
 #ifndef NDEBUG
-            qDebug() << "Session file root is not an array";
+            qDebug() << tr("Session file root is not an array");
 #endif
             return;
         }
@@ -3342,8 +3341,8 @@ Lektra::LoadSession(QString sessionName) noexcept
     {
 
         QMessageBox::critical(
-            this, "Open Session",
-            QStringLiteral("Could not open session: %1").arg(sessionName));
+            this, tr("Open Session"),
+            tr("Could not open session: %1").arg(sessionName));
     }
 }
 
@@ -3358,8 +3357,8 @@ Lektra::getSessionFiles() noexcept
         if (!m_session_dir.mkpath("."))
         {
             QMessageBox::warning(
-                this, "Session Directory",
-                "Unable to create sessions directory for some reason");
+                this, tr("Session Directory"),
+                tr("Unable to create sessions directory due to an unknown error."));
             return sessions;
         }
     }
@@ -3377,8 +3376,8 @@ Lektra::SaveSession() noexcept
 {
     if (!m_doc)
     {
-        QMessageBox::information(this, "Save Session",
-                                 "No files in session to save the session");
+        QMessageBox::information(this, tr("Save Session"),
+                                 tr("No files in session to save the session"));
         return;
     }
 
@@ -3395,8 +3394,8 @@ Lektra::SaveSession() noexcept
 
         if (sessionName.isEmpty())
         {
-            QMessageBox::information(this, "Save Session",
-                                     "Session name cannot be empty");
+            QMessageBox::information(this, tr("Save Session"),
+                                     tr("Session name cannot be empty"));
             return;
         }
 
@@ -3406,8 +3405,8 @@ Lektra::SaveSession() noexcept
             if (existingSessions.contains(sessionName))
             {
                 auto choice = QMessageBox::warning(
-                    this, "Overwrite Session",
-                    QString("Session named \"%1\" already exists. Do you "
+                    this, tr("Overwrite Session"),
+                    tr("Session named \"%1\" already exists. Do you "
                             "want to "
                             "overwrite it?")
                         .arg(sessionName),
@@ -3454,8 +3453,8 @@ Lektra::writeSessionToFile() noexcept
     if (!file.open(QIODevice::WriteOnly))
     {
         QMessageBox::critical(
-            this, "Save Session",
-            QStringLiteral("Could not save session: %1").arg(m_session_name));
+            this, tr("Save Session"),
+            tr("Could not save session: %1").arg(m_session_name));
         return;
     }
     file.write(QJsonDocument(sessionArray).toJson());
@@ -3470,16 +3469,17 @@ Lektra::SaveAsSession(const QString &sessionPath) noexcept
     if (m_session_name.isEmpty())
     {
         QMessageBox::information(
-            this, "Save As Session",
-            "Cannot save session as you are not currently in a session");
+            this, tr("Save As Session"),
+            tr("Cannot save session as you are not currently in a session")
+        );
         return;
     }
 
     QStringList existingSessions = getSessionFiles();
 
     QString selectedPath = QFileDialog::getSaveFileName(
-        this, "Save As Session", m_session_dir.absolutePath(),
-        "Lektra session files (*.json); All Files (*.*)");
+        this, tr("Save As Session"), m_session_dir.absolutePath(),
+        tr("Lektra session files") + " " + "(*.json);" + tr("All Files") + " " + "(*.*)");
 
     if (selectedPath.isEmpty())
         return;
@@ -3487,8 +3487,8 @@ Lektra::SaveAsSession(const QString &sessionPath) noexcept
     if (QFile::exists(selectedPath))
     {
         auto choice = QMessageBox::warning(
-            this, "Overwrite Session",
-            QString("Session named \"%1\" already exists. Do you want to "
+            this, tr("Overwrite Session"),
+            tr("Session named \"%1\" already exists. Do you want to "
                     "overwrite it?")
                 .arg(QFileInfo(selectedPath).fileName()),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
@@ -3502,8 +3502,8 @@ Lektra::SaveAsSession(const QString &sessionPath) noexcept
         = m_session_dir.filePath(m_session_name + ".json");
     if (!QFile::copy(currentSessionPath, selectedPath))
     {
-        QMessageBox::critical(this, "Save As Session",
-                              "Failed to save session.");
+        QMessageBox::critical(this, tr("Save As Session"),
+                              tr("Failed to save session."));
     }
 }
 
@@ -3530,9 +3530,9 @@ Lektra::showStartupWidget() noexcept
                 m_tab_widget->tabCloseRequested(index);
         });
     });
-    int index = m_tab_widget->addTab(m_startup_widget, "Startup");
+    int index = m_tab_widget->addTab(m_startup_widget, tr("Startup"));
     m_tab_widget->setCurrentIndex(index);
-    m_statusbar->setFileName("Start Page");
+    m_statusbar->setFileName(tr("Start Page"));
 }
 
 // Update actions and stuff for system tabs
@@ -3541,7 +3541,7 @@ Lektra::updateActionsAndStuffForSystemTabs() noexcept
 {
     m_statusbar->hidePageInfo(true);
     updateUiEnabledState();
-    m_statusbar->setFileName("Start Page");
+    m_statusbar->setFileName(tr("Start Page"));
 }
 
 // Undo operation
@@ -3573,301 +3573,301 @@ Lektra::initCommands() noexcept
 {
     // Selection
     m_command_manager.reg("selection_copy",
-                          "Copy current selection to clipboard",
+                          tr("Copy current selection to clipboard"),
                           [this](const QStringList &) { Selection_copy(); });
     m_command_manager.reg("selection_cancel",
-                          "Cancel and clear current selection",
+                          tr("Cancel and clear current selection"),
                           [this](const QStringList &) { Selection_cancel(); });
-    m_command_manager.reg("selection_last", "Reselect the last text selection",
+    m_command_manager.reg("selection_last", tr("Reselect the last text selection"),
                           [this](const QStringList &)
     { ReselectLastTextSelection(); });
 
     // Toggles
-    m_command_manager.reg("presentation_mode", "Toggle presentation mode",
+    m_command_manager.reg("presentation_mode", tr("Toggle presentation mode"),
                           [this](const QStringList &)
     { Toggle_presentation_mode(); });
-    m_command_manager.reg("fullscreen", "Toggle fullscreen",
+    m_command_manager.reg("fullscreen", tr("Toggle fullscreen"),
                           [this](const QStringList &) { ToggleFullscreen(); });
-    m_command_manager.reg("command_palette", "Open command palette",
+    m_command_manager.reg("command_palette", tr("Open command palette"),
                           [this](const QStringList &)
     { Show_command_picker(); });
-    m_command_manager.reg("tabs", "Toggle tab bar",
+    m_command_manager.reg("tabs", tr("Toggle tab bar"),
                           [this](const QStringList &) { ToggleTabBar(); });
-    m_command_manager.reg("menubar", "Toggle menu bar",
+    m_command_manager.reg("menubar", tr("Toggle menu bar"),
                           [this](const QStringList &) { ToggleMenubar(); });
-    m_command_manager.reg("statusbar", "Toggle status bar",
+    m_command_manager.reg("statusbar", tr("Toggle status bar"),
                           [this](const QStringList &) { TogglePanel(); });
-    m_command_manager.reg("focus_mode", "Toggle focus mode",
+    m_command_manager.reg("focus_mode", tr("Toggle focus mode"),
                           [this](const QStringList &) { ToggleFocusMode(); });
-    m_command_manager.reg("visual_line_mode", "Toggle visual line mode",
+    m_command_manager.reg("visual_line_mode", tr("Toggle visual line mode"),
                           [this](const QStringList &)
     { Toggle_visual_line_mode(); });
 
 #ifdef ENABLE_LLM_SUPPORT
-    m_command_manager.reg("llm_widget", "Toggle LLM assistant widget",
+    m_command_manager.reg("llm_widget", tr("Toggle LLM assistant widget"),
                           [this](const QStringList &) { ToggleLLMWidget(); });
 #endif
 
     // Link hints
-    m_command_manager.reg("link_hint_visit", "Open link using keyboard hint",
+    m_command_manager.reg("link_hint_visit", tr("Open link using keyboard hint"),
                           [this](const QStringList &) { VisitLinkKB(); });
-    m_command_manager.reg("link_hint_copy", "Copy link URL using keyboard hint",
+    m_command_manager.reg("link_hint_copy", tr("Copy link URL using keyboard hint"),
                           [this](const QStringList &) { CopyLinkKB(); });
 
     // Page navigation
-    m_command_manager.reg("page_first", "Go to first page",
+    m_command_manager.reg("page_first", tr("Go to first page"),
                           [this](const QStringList &) { FirstPage(); });
-    m_command_manager.reg("page_last", "Go to last page",
+    m_command_manager.reg("page_last", tr("Go to last page"),
                           [this](const QStringList &) { LastPage(); });
-    m_command_manager.reg("page_next", "Go to next page",
+    m_command_manager.reg("page_next", tr("Go to next page"),
                           [this](const QStringList &) { NextPage(); });
-    m_command_manager.reg("page_prev", "Go to previous page",
+    m_command_manager.reg("page_prev", tr("Go to previous page"),
                           [this](const QStringList &) { PrevPage(); });
-    m_command_manager.reg("page_goto", "Jump to a specific page number",
+    m_command_manager.reg("page_goto", tr("Jump to a specific page number"),
                           [this](const QStringList &) { Goto_page(); });
 
     // Marks
-    m_command_manager.reg("mark_set", "Set a named mark at current position",
+    m_command_manager.reg("mark_set", tr("Set a named mark at current position"),
                           [this](const QStringList &) { SetMark(); });
-    m_command_manager.reg("mark_delete", "Delete a named mark",
+    m_command_manager.reg("mark_delete", tr("Delete a named mark"),
                           [this](const QStringList &) { DeleteMark(); });
-    m_command_manager.reg("mark_goto", "Jump to a named mark",
+    m_command_manager.reg("mark_goto", tr("Jump to a named mark"),
                           [this](const QStringList &) { GotoMark(); });
 
     // Scrolling
-    m_command_manager.reg("scroll_down", "Scroll down",
+    m_command_manager.reg("scroll_down", tr("Scroll down"),
                           [this](const QStringList &) { ScrollDown(); });
-    m_command_manager.reg("scroll_up", "Scroll up",
+    m_command_manager.reg("scroll_up", tr("Scroll up"),
                           [this](const QStringList &) { ScrollUp(); });
-    m_command_manager.reg("scroll_left", "Scroll left",
+    m_command_manager.reg("scroll_left", tr("Scroll left"),
                           [this](const QStringList &) { ScrollLeft(); });
-    m_command_manager.reg("scroll_right", "Scroll right",
+    m_command_manager.reg("scroll_right", tr("Scroll right"),
                           [this](const QStringList &) { ScrollRight(); });
 
     // Rotation
-    m_command_manager.reg("rotate_clock", "Rotate page clockwise",
+    m_command_manager.reg("rotate_clock", tr("Rotate page clockwise"),
                           [this](const QStringList &) { RotateClock(); });
-    m_command_manager.reg("rotate_anticlock", "Rotate page counter-clockwise",
+    m_command_manager.reg("rotate_anticlock", tr("Rotate page counter-clockwise"),
                           [this](const QStringList &) { RotateAnticlock(); });
 
     // Location history
-    m_command_manager.reg("location_prev", "Go back in location history",
+    m_command_manager.reg("location_prev", tr("Go back in location history"),
                           [this](const QStringList &) { GoBackHistory(); });
-    m_command_manager.reg("location_next", "Go forward in location history",
+    m_command_manager.reg("location_next", tr("Go forward in location history"),
                           [this](const QStringList &) { GoForwardHistory(); });
 
     // Zoom
-    m_command_manager.reg("zoom_in", "Zoom in",
+    m_command_manager.reg("zoom_in", tr("Zoom in"),
                           [this](const QStringList &) { ZoomIn(); });
-    m_command_manager.reg("zoom_out", "Zoom out",
+    m_command_manager.reg("zoom_out", tr("Zoom out"),
                           [this](const QStringList &) { ZoomOut(); });
-    m_command_manager.reg("zoom_reset", "Reset zoom to default",
+    m_command_manager.reg("zoom_reset", tr("Reset zoom to default"),
                           [this](const QStringList &) { ZoomReset(); });
-    m_command_manager.reg("zoom_set", "Set zoom to a specific level",
+    m_command_manager.reg("zoom_set", tr("Set zoom to a specific level"),
                           [this](const QStringList &) { Zoom_set(); });
 
     // Splits
-    m_command_manager.reg("split_horizontal", "Split view horizontally",
+    m_command_manager.reg("split_horizontal", tr("Split view horizontally"),
                           [this](const QStringList &) { VSplit(); });
-    m_command_manager.reg("split_vertical", "Split view vertically",
+    m_command_manager.reg("split_vertical", tr("Split view vertically"),
                           [this](const QStringList &) { HSplit(); });
-    m_command_manager.reg("split_close", "Close current split",
+    m_command_manager.reg("split_close", tr("Close current split"),
                           [this](const QStringList &) { Close_split(); });
-    m_command_manager.reg("split_focus_right", "Focus split to the right",
+    m_command_manager.reg("split_focus_right", tr("Focus split to the right"),
                           [this](const QStringList &) { Focus_split_right(); });
-    m_command_manager.reg("split_focus_left", "Focus split to the left",
+    m_command_manager.reg("split_focus_left", tr("Focus split to the left"),
                           [this](const QStringList &) { Focus_split_left(); });
-    m_command_manager.reg("split_focus_up", "Focus split above",
+    m_command_manager.reg("split_focus_up", tr("Focus split above"),
                           [this](const QStringList &) { Focus_split_up(); });
-    m_command_manager.reg("split_focus_down", "Focus split below",
+    m_command_manager.reg("split_focus_down", tr("Focus split below"),
                           [this](const QStringList &) { Focus_split_down(); });
     m_command_manager.reg(
-        "split_close_others", "Close all splits except current",
+        "split_close_others", tr("Close all splits except current"),
         [this](const QStringList &) { Close_other_splits(); });
 
     // Portal
-    m_command_manager.reg("portal", "Create or focus portal",
+    m_command_manager.reg("portal", tr("Create or focus portal"),
                           [this](const QStringList &)
     { Create_or_focus_portal(); });
 
     // File operations
-    m_command_manager.reg("file_open_tab", "Open file in new tab",
+    m_command_manager.reg("file_open_tab", tr("Open file in new tab"),
                           [this](const QStringList &) { OpenFileInNewTab(); });
-    m_command_manager.reg("file_open_vsplit", "Open file in vertical split",
+    m_command_manager.reg("file_open_vsplit", tr("Open file in vertical split"),
                           [this](const QStringList &) { OpenFileVSplit(); });
-    m_command_manager.reg("file_open_hsplit", "Open file in horizontal split",
+    m_command_manager.reg("file_open_hsplit", tr("Open file in horizontal split"),
                           [this](const QStringList &) { OpenFileHSplit(); });
-    m_command_manager.reg("file_open_dwim", "Open file (do what I mean)",
+    m_command_manager.reg("file_open_dwim", tr("Open file (do what I mean)"),
                           [this](const QStringList &) { OpenFileDWIM(); });
-    m_command_manager.reg("file_close", "Close current file",
+    m_command_manager.reg("file_close", tr("Close current file"),
                           [this](const QStringList &) { CloseFile(); });
-    m_command_manager.reg("file_save", "Save current file",
+    m_command_manager.reg("file_save", tr("Save current file"),
                           [this](const QStringList &) { SaveFile(); });
-    m_command_manager.reg("file_save_as", "Save current file as a new name",
+    m_command_manager.reg("file_save_as", tr("Save current file as a new name"),
                           [this](const QStringList &) { SaveAsFile(); });
-    m_command_manager.reg("file_encrypt", "Encrypt current document",
+    m_command_manager.reg("file_encrypt", tr("Encrypt current document"),
                           [this](const QStringList &) { EncryptDocument(); });
-    m_command_manager.reg("file_decrypt", "Decrypt current document",
+    m_command_manager.reg("file_decrypt", tr("Decrypt current document"),
                           [this](const QStringList &) { DecryptDocument(); });
-    m_command_manager.reg("file_reload", "Reload current file from disk",
+    m_command_manager.reg("file_reload", tr("Reload current file from disk"),
                           [this](const QStringList &) { reloadDocument(); });
-    m_command_manager.reg("file_properties", "Show file properties",
+    m_command_manager.reg("file_properties", tr("Show file properties"),
                           [this](const QStringList &) { FileProperties(); });
-    m_command_manager.reg("files_recent", "Show recently opened files",
+    m_command_manager.reg("files_recent", tr("Show recently opened files"),
                           [this](const QStringList &)
     { Show_recent_files_picker(); });
 
     // Annotation modes
-    m_command_manager.reg("annot_edit_mode", "Toggle annotation select mode",
+    m_command_manager.reg("annot_edit_mode", tr("Toggle annotation select mode"),
                           [this](const QStringList &) { ToggleAnnotSelect(); });
-    m_command_manager.reg("annot_popup_mode", "Toggle annotation popup mode",
+    m_command_manager.reg("annot_popup_mode", tr("Toggle annotation popup mode"),
                           [this](const QStringList &) { ToggleAnnotPopup(); });
-    m_command_manager.reg("annot_rect_mode", "Toggle rectangle annotation mode",
+    m_command_manager.reg("annot_rect_mode", tr("Toggle rectangle annotation mode"),
                           [this](const QStringList &) { ToggleAnnotRect(); });
-    m_command_manager.reg("annot_highlight_mode", "Toggle text highlight mode",
+    m_command_manager.reg("annot_highlight_mode", tr("Toggle text highlight mode"),
                           [this](const QStringList &)
     { ToggleTextHighlight(); });
-    m_command_manager.reg("none_mode", "Toggle none interaction mode",
+    m_command_manager.reg("none_mode", tr("Toggle none interaction mode"),
                           [this](const QStringList &) { Toggle_none_mode(); });
 
     // Selection modes
     m_command_manager.reg(
-        "selection_mode_text", "Switch to text selection mode",
+        "selection_mode_text", tr("Switch to text selection mode"),
         [this](const QStringList &) { ToggleTextSelection(); });
     m_command_manager.reg(
-        "selection_mode_region", "Switch to region selection mode",
+        "selection_mode_region", tr("Switch to region selection mode"),
         [this](const QStringList &) { ToggleRegionSelect(); });
 
     // Fit modes
-    m_command_manager.reg("fit_width", "Fit page to window width",
+    m_command_manager.reg("fit_width", tr("Fit page to window width"),
                           [this](const QStringList &) { Fit_width(); });
-    m_command_manager.reg("fit_height", "Fit page to window height",
+    m_command_manager.reg("fit_height", tr("Fit page to window height"),
                           [this](const QStringList &) { Fit_height(); });
-    m_command_manager.reg("fit_page", "Fit entire page in window",
+    m_command_manager.reg("fit_page", tr("Fit entire page in window"),
                           [this](const QStringList &) { Fit_page(); });
-    m_command_manager.reg("fit_auto", "Toggle automatic resize to fit",
+    m_command_manager.reg("fit_auto", tr("Toggle automatic resize to fit"),
                           [this](const QStringList &) { ToggleAutoResize(); });
 
     // Sessions
-    m_command_manager.reg("session_save", "Save current session",
+    m_command_manager.reg("session_save", tr("Save current session"),
                           [this](const QStringList &) { SaveSession(); });
     m_command_manager.reg("session_save_as",
-                          "Save current session under a new name",
+                          tr("Save current session under a new name"),
                           [this](const QStringList &) { SaveAsSession(); });
-    m_command_manager.reg("session_load", "Load a saved session",
+    m_command_manager.reg("session_load", tr("Load a saved session"),
                           [this](const QStringList &) { LoadSession(); });
 
     // Tabs
-    m_command_manager.reg("tabs_close_left", "Close all tabs to the left",
+    m_command_manager.reg("tabs_close_left", tr("Close all tabs to the left"),
                           [this](const QStringList &) { TabsCloseLeft(); });
-    m_command_manager.reg("tabs_close_right", "Close all tabs to the right",
+    m_command_manager.reg("tabs_close_right", tr("Close all tabs to the right"),
                           [this](const QStringList &) { TabsCloseRight(); });
-    m_command_manager.reg("tabs_close_others", "Close all tabs except current",
+    m_command_manager.reg("tabs_close_others", tr("Close all tabs except current"),
                           [this](const QStringList &) { TabsCloseOthers(); });
-    m_command_manager.reg("tab_move_right", "Move current tab right",
+    m_command_manager.reg("tab_move_right", tr("Move current tab right"),
                           [this](const QStringList &) { TabMoveRight(); });
-    m_command_manager.reg("tab_move_left", "Move current tab left",
+    m_command_manager.reg("tab_move_left", tr("Move current tab left"),
                           [this](const QStringList &) { TabMoveLeft(); });
-    m_command_manager.reg("tab_first", "Switch to first tab",
+    m_command_manager.reg("tab_first", tr("Switch to first tab"),
                           [this](const QStringList &) { Tab_first(); });
-    m_command_manager.reg("tab_last", "Switch to last tab",
+    m_command_manager.reg("tab_last", tr("Switch to last tab"),
                           [this](const QStringList &) { Tab_last(); });
-    m_command_manager.reg("tab_next", "Switch to next tab",
+    m_command_manager.reg("tab_next", tr("Switch to next tab"),
                           [this](const QStringList &) { Tab_next(); });
-    m_command_manager.reg("tab_prev", "Switch to previous tab",
+    m_command_manager.reg("tab_prev", tr("Switch to previous tab"),
                           [this](const QStringList &) { Tab_prev(); });
-    m_command_manager.reg("tab_close", "Close current tab",
+    m_command_manager.reg("tab_close", tr("Close current tab"),
                           [this](const QStringList &) { Tab_close(); });
-    m_command_manager.reg("tab_goto", "Go to tab by number",
+    m_command_manager.reg("tab_goto", tr("Go to tab by number"),
                           [this](const QStringList &) { Tab_goto(); });
-    m_command_manager.reg("tab_1", "Switch to tab 1",
+    m_command_manager.reg("tab_1", tr("Switch to tab 1"),
                           [this](const QStringList &) { Tab_goto(1); });
-    m_command_manager.reg("tab_2", "Switch to tab 2",
+    m_command_manager.reg("tab_2", tr("Switch to tab 2"),
                           [this](const QStringList &) { Tab_goto(2); });
-    m_command_manager.reg("tab_3", "Switch to tab 3",
+    m_command_manager.reg("tab_3", tr("Switch to tab 3"),
                           [this](const QStringList &) { Tab_goto(3); });
-    m_command_manager.reg("tab_4", "Switch to tab 4",
+    m_command_manager.reg("tab_4", tr("Switch to tab 4"),
                           [this](const QStringList &) { Tab_goto(4); });
-    m_command_manager.reg("tab_5", "Switch to tab 5",
+    m_command_manager.reg("tab_5", tr("Switch to tab 5"),
                           [this](const QStringList &) { Tab_goto(5); });
-    m_command_manager.reg("tab_6", "Switch to tab 6",
+    m_command_manager.reg("tab_6", tr("Switch to tab 6"),
                           [this](const QStringList &) { Tab_goto(6); });
-    m_command_manager.reg("tab_7", "Switch to tab 7",
+    m_command_manager.reg("tab_7", tr("Switch to tab 7"),
                           [this](const QStringList &) { Tab_goto(7); });
-    m_command_manager.reg("tab_8", "Switch to tab 8",
+    m_command_manager.reg("tab_8", tr("Switch to tab 8"),
                           [this](const QStringList &) { Tab_goto(8); });
-    m_command_manager.reg("tab_9", "Switch to tab 9",
+    m_command_manager.reg("tab_9", tr("Switch to tab 9"),
                           [this](const QStringList &) { Tab_goto(9); });
 
     // Pickers
-    m_command_manager.reg("picker_outline", "Open document outline picker",
+    m_command_manager.reg("picker_outline", tr("Open document outline picker"),
                           [this](const QStringList &) { Show_outline(); });
-    m_command_manager.reg("picker_highlight_search", "Search within highlights",
+    m_command_manager.reg("picker_highlight_search", tr("Search within highlights"),
                           [this](const QStringList &)
     { Show_highlight_search(); });
 
     // Search
     m_command_manager.reg("search", "Search document",
                           [this](const QStringList &) { Search(); });
-    m_command_manager.reg("search_regex", "Search document using regex",
+    m_command_manager.reg("search_regex", tr("Search document using regex"),
                           [this](const QStringList &) { Search_regex(); });
-    m_command_manager.reg("search_next", "Jump to next search result",
+    m_command_manager.reg("search_next", tr("Jump to next search result"),
                           [this](const QStringList &) { NextHit(); });
-    m_command_manager.reg("search_prev", "Jump to previous search result",
+    m_command_manager.reg("search_prev", tr("Jump to previous search result"),
                           [this](const QStringList &) { PrevHit(); });
-    m_command_manager.reg("search_args", "Search with inline query argument",
+    m_command_manager.reg("search_args", tr("Search with inline query argument"),
                           [this](const QStringList &args)
     { search(args.join(" ")); });
 
     // Layout modes
-    m_command_manager.reg("layout_single", "Single page layout",
+    m_command_manager.reg("layout_single", tr("Single page layout"),
                           [this](const QStringList &)
     { SetLayoutMode(DocumentView::LayoutMode::SINGLE); });
     m_command_manager.reg("layout_horizontal",
-                          "Horizontal (left to right) layout",
+                          tr("Horizontal (left to right) layout"),
                           [this](const QStringList &)
     { SetLayoutMode(DocumentView::LayoutMode::HORIZONTAL); });
-    m_command_manager.reg("layout_vertical", "Vertical (top to bottom) layout",
+    m_command_manager.reg("layout_vertical", tr("Vertical (top to bottom) layout"),
                           [this](const QStringList &)
     { SetLayoutMode(DocumentView::LayoutMode::VERTICAL); });
-    m_command_manager.reg("layout_book", "Book (two page spread) layout",
+    m_command_manager.reg("layout_book", tr("Book (two page spread) layout"),
                           [this](const QStringList &)
     { SetLayoutMode(DocumentView::LayoutMode::BOOK); });
 
     // Miscellaneous
-    m_command_manager.reg("set_dpr", "Set device pixel ratio",
+    m_command_manager.reg("set_dpr", tr("Set device pixel ratio"),
                           [this](const QStringList &) { SetDPR(); });
     m_command_manager.reg(
-        "open_containing_folder", "Open folder containing current file",
+        "open_containing_folder", tr("Open folder containing current file"),
         [this](const QStringList &) { OpenContainingFolder(); });
-    m_command_manager.reg("undo", "Undo last action",
+    m_command_manager.reg("undo", tr("Undo last action"),
                           [this](const QStringList &) { Undo(); });
-    m_command_manager.reg("redo", "Redo last undone action",
+    m_command_manager.reg("redo", tr("Redo last undone action"),
                           [this](const QStringList &) { Redo(); });
     m_command_manager.reg(
-        "highlight_selection", "Highlight current text selection",
+        "highlight_selection", tr("Highlight current text selection"),
         [this](const QStringList &) { TextHighlightCurrentSelection(); });
-    m_command_manager.reg("invert_color", "Toggle inverted colour rendering",
+    m_command_manager.reg("invert_color", tr("Toggle inverted colour rendering"),
                           [this](const QStringList &) { InvertColor(); });
-    m_command_manager.reg("reshow_jump_marker", "Re-show the last jump marker",
+    m_command_manager.reg("reshow_jump_marker", tr("Re-show the last jump marker"),
                           [this](const QStringList &)
     { Reshow_jump_marker(); });
-    m_command_manager.reg("reopen_last_closed_file", "Reopen last closed file",
+    m_command_manager.reg("reopen_last_closed_file", tr("Reopen last closed file"),
                           [this](const QStringList &)
     { Reopen_last_closed_file(); });
-    m_command_manager.reg("copy_page_image", "Copy current page as image",
+    m_command_manager.reg("copy_page_image", tr("Copy current page as image"),
                           [this](const QStringList &) { Copy_page_image(); });
 #ifndef NDEBUG
-    m_command_manager.reg("debug_command", "Run debug command",
+    m_command_manager.reg("debug_command", tr("Run debug command"),
                           [this](const QStringList &) { debug_command(); });
 #endif
 
     // Help / About
-    m_command_manager.reg("show_startup_widget", "Show startup screen",
+    m_command_manager.reg("show_startup_widget", tr("Show startup screen"),
                           [this](const QStringList &) { showStartupWidget(); });
-    m_command_manager.reg("show_tutorial_file", "Open tutorial document",
+    m_command_manager.reg("show_tutorial_file", tr("Open tutorial document"),
                           [this](const QStringList &) { showTutorialFile(); });
-    m_command_manager.reg("show_about", "Show about dialog",
+    m_command_manager.reg("show_about", tr("Show about dialog"),
                           [this](const QStringList &) { ShowAbout(); });
 }
 
@@ -3882,7 +3882,7 @@ Lektra::trimRecentFilesDatabase() noexcept
 
     m_recent_files_store.trim(m_config.behavior.num_recent_files);
     if (!m_recent_files_store.save())
-        qWarning() << "Failed to trim recent files store";
+        qWarning() << tr("Failed to trim recent files store");
 }
 
 // Sets the DPR of the current document
@@ -3894,12 +3894,12 @@ Lektra::SetDPR() noexcept
         QInputDialog id;
         bool ok;
         float dpr = id.getDouble(
-            this, "Set DPR", "Enter the Device Pixel Ratio (DPR) value: ", 1.0,
+            this, tr("Set DPR"), tr("Enter the Device Pixel Ratio (DPR) value: "), 1.0,
             0.0, 10.0, 2, &ok);
         if (ok)
             m_doc->setDPR(dpr);
         else
-            QMessageBox::critical(this, "Set DPR", "Invalid DPR value");
+            QMessageBox::critical(this, tr("Set DPR"), ("Invalid DPR value"));
     }
 }
 
@@ -3963,14 +3963,14 @@ Lektra::Tab_goto(int index) noexcept
 {
     if (index == -1)
     {
-        index = QInputDialog::getInt(this, "Go to Tab", "Enter tab number: ", 1,
+        index = QInputDialog::getInt(this, tr("Go to Tab"), tr("Enter tab number: "), 1,
                                      1, m_tab_widget->count());
     }
 
     if (index > 0 || index < m_tab_widget->count())
         m_tab_widget->setCurrentIndex(index - 1);
     else
-        m_message_bar->showMessage("Invalid Tab Number");
+        m_message_bar->showMessage(tr("Invalid Tab Number"));
 }
 
 // Close the current tab
@@ -4280,7 +4280,7 @@ Lektra::modeColorChangeRequested(const GraphicsView::Mode mode) noexcept
     // FIXME: Make this a function
     QColorDialog colorDialog(this);
     colorDialog.setOption(QColorDialog::ShowAlphaChannel, true);
-    colorDialog.setWindowTitle("Select Color");
+    colorDialog.setWindowTitle(tr("Select Color"));
     if (colorDialog.exec() == QDialog::Accepted)
     {
         QColor color = colorDialog.selectedColor();
@@ -4317,7 +4317,7 @@ void
 Lektra::handleEscapeKeyPressed() noexcept
 {
 #ifndef NDEBUG
-    qDebug() << "Escape key pressed handled";
+    qDebug() << tr("Escape key pressed handled");
 #endif
 
     m_lockedInputBuffer.clear();
@@ -4361,11 +4361,11 @@ Lektra::showTutorialFile() noexcept
                                  .arg("/share/doc/Lektra/tutorial.pdf");
     OpenFileInNewTab(doc_path);
 #elif defined(__APPLE__) && defined(__MACH__)
-    QMessageBox::warning(this, "Show Tutorial File",
-                         "Not yet implemented for Macintosh");
+    QMessageBox::warning(this, tr("Show Tutorial File"),
+                         tr("Not yet implemented for Mac"));
 #elif defined(_WIN64)
     QMessageBox::warning(this, "Show Tutorial File",
-                         "Not yet implemented for Windows");
+                         tr("Not yet implemented for Windows"));
 #endif
 }
 
@@ -4960,8 +4960,8 @@ Lektra::Show_recent_files_picker() noexcept
 
     if (entries.empty())
     {
-        QMessageBox::information(this, "Recent Files",
-                                 "No recent files found.");
+        QMessageBox::information(this, tr("Recent Files"),
+                                 tr("No recent files found."));
         return;
     }
 
@@ -5019,7 +5019,7 @@ Lektra::Reopen_last_closed_file() noexcept
 
     if (!QFile::exists(target->file_path))
     {
-        qWarning() << "Reopen_last_file: file no longer exists:"
+        qWarning() << tr("Reopen_last_file: file no longer exists:")
                    << target->file_path;
         return;
     }
@@ -5037,11 +5037,11 @@ Lektra::SetMark() noexcept
         return;
 
     const QString key = QInputDialog::getText(
-        this, "Set Mark", "Enter mark key (a-z for local, A-Z for global):");
+        this, tr("Set Mark"), tr("Enter mark key (a-z for local, A-Z for global):"));
 
     if (key.isEmpty())
     {
-        QMessageBox::critical(this, "Set Mark", "Mark key cannot be empty");
+        QMessageBox::critical(this, tr("Set Mark"), tr("Mark key cannot be empty"));
         return;
     }
 
@@ -5061,11 +5061,11 @@ Lektra::DeleteMark() noexcept
 
     const QStringList existingMarks = m_marks_manager->allKeys(m_doc->id());
     const QString key               = QInputDialog::getItem(
-        this, "Delete Mark", "Mark to delete:", existingMarks, 0);
+        this, tr("Delete Mark"), tr("Mark to delete:"), existingMarks, 0);
 
     if (key.isEmpty())
     {
-        QMessageBox::critical(this, "Delete Mark", "Mark key cannot be empty");
+        QMessageBox::critical(this, tr("Delete Mark"), tr("Mark key cannot be empty"));
         return;
     }
 
@@ -5087,11 +5087,11 @@ Lektra::GotoMark() noexcept
 
     const QStringList existingMarks = m_marks_manager->allKeys(m_doc->id());
     const QString key               = QInputDialog::getItem(
-        this, "Goto Mark", "Mark to go to:", existingMarks, 0);
+        this, tr("Goto Mark"), tr("Mark to go to:"), existingMarks, 0);
 
     if (key.isEmpty())
     {
-        QMessageBox::critical(this, "Goto Mark", "Mark key cannot be empty");
+        QMessageBox::critical(this, tr("Goto Mark"), tr("Mark key cannot be empty"));
         return;
     }
 

--- a/src/Statusbar.cpp
+++ b/src/Statusbar.cpp
@@ -117,49 +117,49 @@ Statusbar::setMode(GraphicsView::Mode mode) noexcept
     {
         case GraphicsView::Mode::RegionSelection:
         {
-            m_mode_label->setText("Region Selection");
+            m_mode_label->setText(tr("Region Selection"));
             show_color = false;
         }
         break;
 
         case GraphicsView::Mode::TextSelection:
         {
-            m_mode_label->setText("Text Selection");
+            m_mode_label->setText(tr("Text Selection"));
             show_color = false;
         }
         break;
 
         case GraphicsView::Mode::TextHighlight:
         {
-            m_mode_label->setText("Text Highlight");
+            m_mode_label->setText(tr("Text Highlight"));
             show_color = true;
         }
         break;
 
         case GraphicsView::Mode::AnnotSelect:
         {
-            m_mode_label->setText("Annot Select");
+            m_mode_label->setText(tr("Annot Select"));
             show_color = false;
         }
         break;
 
         case GraphicsView::Mode::AnnotRect:
         {
-            m_mode_label->setText("Annot Rect");
+            m_mode_label->setText(tr("Annot Rect"));
             show_color = true;
         }
         break;
 
         case GraphicsView::Mode::AnnotPopup:
         {
-            m_mode_label->setText("Annot Popup");
+            m_mode_label->setText(tr("Annot Popup"));
             show_color = true;
         }
         break;
 
         case GraphicsView::Mode::VisualLine:
         {
-            m_mode_label->setText("Visual Line");
+            m_mode_label->setText(tr("Visual Line"));
             show_color = false;
         }
         break;

--- a/src/Statusbar.hpp
+++ b/src/Statusbar.hpp
@@ -45,7 +45,7 @@ private:
     CircleLabel *m_mode_color_label = new CircleLabel();
     QLabel *m_pageno_label          = new QLabel();
     QLabel *m_totalpage_label       = new QLabel();
-    QLabel *m_pageno_separator      = new QLabel(" of ");
+    QLabel *m_pageno_separator      = new QLabel(" " + tr("of") + " ");
     QLabel *m_progress_label        = new QLabel();
     QLabel *m_portal_label          = new QLabel("P");
     QPushButton *m_session_label    = new QPushButton();

--- a/src/Translations/lektra.es.ts
+++ b/src/Translations/lektra.es.ts
@@ -1,0 +1,1553 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es_ES">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../AboutDialog.cpp" line="26"/>
+        <location filename="../AboutDialog.cpp" line="85"/>
+        <source>About</source>
+        <translation>Acerca de</translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="88"/>
+        <source>Libraries Used</source>
+        <translation>Bibliotecas en uso</translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="89"/>
+        <source>License</source>
+        <translation>Licencia</translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="125"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="126"/>
+        <source>Created by</source>
+        <translation>Creado por</translation>
+    </message>
+</context>
+<context>
+    <name>DocumentView</name>
+    <message>
+        <location filename="../DocumentView.cpp" line="532"/>
+        <source>Search</source>
+        <translation>Buscar</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="533"/>
+        <source>No matches found for the given term.</source>
+        <translation>No se encontraron coincidencias para este término.</translation>
+    </message>
+    <message>
+        <source>Edit Note</source>
+        <translation type="vanished">Editar nota</translation>
+    </message>
+    <message>
+        <source>Edit annotation text:</source>
+        <translation type="vanished">Editar anotación:</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3453"/>
+        <source>Add Comment</source>
+        <translation>Añadir comentario</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3453"/>
+        <source>Enter annotation comment:</source>
+        <translation>Escribir comenntario de la anotación:</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3996"/>
+        <source>Save Image</source>
+        <translation>Guardar imagen</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3997"/>
+        <source>PNG Image</source>
+        <translation>imagen PNG</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3998"/>
+        <source>JPEG Image</source>
+        <translation>imagen JPG</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3999"/>
+        <source>BMP Image</source>
+        <translation>imagen BMP</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4222"/>
+        <source>Add Note</source>
+        <translation>Añadir nota</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4222"/>
+        <source>Enter annotation text:</source>
+        <translation>Texto de la anotación:</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4456"/>
+        <source>Password Required</source>
+        <translation>Se requiere contraseña</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4456"/>
+        <source>Enter password:</source>
+        <translation>Escribe la contraseña:</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4475"/>
+        <source>Incorrect Password</source>
+        <translation>Contraseña incorrecta</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4476"/>
+        <source>The password you entered is incorrect.</source>
+        <translation>La contraseña que escribiste no es correcta.</translation>
+    </message>
+</context>
+<context>
+    <name>EditLastPagesWidget</name>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="16"/>
+        <source>Remove unfound files</source>
+        <translation>Quitar archivos no encontrados</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="17"/>
+        <location filename="../EditLastPagesWidget.cpp" line="121"/>
+        <location filename="../EditLastPagesWidget.cpp" line="126"/>
+        <source>Revert Changes</source>
+        <translation>Deshacer cambios</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="18"/>
+        <source>Delete row</source>
+        <translation>Eliminar fila</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="19"/>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="20"/>
+        <source>Close</source>
+        <translation>Cerrar</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="68"/>
+        <location filename="../EditLastPagesWidget.cpp" line="76"/>
+        <source>Apply Changes</source>
+        <translation>Aplicar cambios</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="68"/>
+        <source>Do you want to apply the changes ?</source>
+        <translation>¿Quieres aplicar los cambios?</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="77"/>
+        <source>Failed to save recent files</source>
+        <translation>No se pudieron guardar los archivos recientes</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="122"/>
+        <source>There are no changes to revert to</source>
+        <translation>No hay cambios para deshacer</translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="126"/>
+        <source>Do you really want to revert the changes ?</source>
+        <translation>¿Estás seguro de que quieres deshacer los cambios?</translation>
+    </message>
+</context>
+<context>
+    <name>HighlightAnnotation</name>
+    <message>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="105"/>
+        <source>Delete</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="106"/>
+        <source>Change Color</source>
+        <translation>Cambiar color</translation>
+    </message>
+    <message>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="107"/>
+        <source>Comment</source>
+        <translation>Comentar</translation>
+    </message>
+</context>
+<context>
+    <name>Lektra</name>
+    <message>
+        <location filename="../Lektra.cpp" line="118"/>
+        <source>&amp;File</source>
+        <translation>&amp;Archivo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="121"/>
+        <source>Open File	%1</source>
+        <translation>Abrir archivo	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="124"/>
+        <source>Open File In VSplit	%1</source>
+        <translation>Abrir archivo en vista dividida vertical	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="128"/>
+        <source>Open File In HSplit	%1</source>
+        <translation>Abrir archivo en vista dividida horizontal	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="132"/>
+        <location filename="../Lektra.cpp" line="4963"/>
+        <source>Recent Files</source>
+        <translation>Archivos recientes</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="135"/>
+        <source>File Properties	%1</source>
+        <translation>Propiedades del archivo	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="140"/>
+        <source>Open Containing Folder	%1</source>
+        <translation>Abrir carpeta contenedora	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="146"/>
+        <source>Save File	%1</source>
+        <translation>Guardar archivo	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="150"/>
+        <source>Save As File	%1</source>
+        <translation>Guardar como archivo	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="153"/>
+        <source>Session</source>
+        <translation>Sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="156"/>
+        <source>Save	%1</source>
+        <translation>Guardar	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="159"/>
+        <source>Save As	%1</source>
+        <translation>Guardar como	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="162"/>
+        <source>Load	%1</source>
+        <translation>Cargar	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="168"/>
+        <source>Close File	%1</source>
+        <translation>Cerrar archivo	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="172"/>
+        <source>Quit</source>
+        <translation>Salir</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="174"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Editar</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="176"/>
+        <source>Undo	%1</source>
+        <translation>Deshacer	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="179"/>
+        <source>Redo	%1</source>
+        <translation>Rehacer	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="184"/>
+        <source>Last Pages	%1</source>
+        <translation>Últimas páginas	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="188"/>
+        <source>&amp;View</source>
+        <translation>&amp;Vista</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="190"/>
+        <source>Fullscreen	%1</source>
+        <translation>Pantalla completa	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="196"/>
+        <source>Zoom In	%1</source>
+        <translation>Acercar	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="199"/>
+        <source>Zoom Out	%1</source>
+        <translation>Alejar	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="204"/>
+        <source>Fit</source>
+        <translation>Ajustar</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="207"/>
+        <source>Width	%1</source>
+        <translation>Al ancho	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="211"/>
+        <source>Height	%1</source>
+        <translation>Al largo	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="215"/>
+        <source>Page	%1</source>
+        <translation>A la página	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="222"/>
+        <source>Auto Fit	%1</source>
+        <translation>Ajuste automático	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="231"/>
+        <source>Layout</source>
+        <translation>Disposición</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="236"/>
+        <source>Single Page	%1</source>
+        <translation>Una sola página	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="240"/>
+        <source>Left to Right Page	%1</source>
+        <translation>Página de izquierda a derecha	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="245"/>
+        <source>Top to Bottom Page	%1</source>
+        <translation>Página de arriba a abajo	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="250"/>
+        <source>Book	%1</source>
+        <translation>Libro	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="275"/>
+        <source>Show/Hide</source>
+        <translation>Mostrar u ocultar</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="279"/>
+        <source>LLM Widget	%1</source>
+        <translation>Widget LLM	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="286"/>
+        <source>Command Picker	%1</source>
+        <translation>Selector de comandos	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="290"/>
+        <source>Outline	%1</source>
+        <translation>Bordes	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="297"/>
+        <source>Highlight Annotation Search	%1</source>
+        <translation>Resaltar búsqueda de anotación	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="305"/>
+        <source>Menubar	%1</source>
+        <translation>Barra de menú	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="311"/>
+        <source>Tabs	%1</source>
+        <translation>Pestañas	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="317"/>
+        <source>Statusbar	%1</source>
+        <translation>Barra de estado	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="323"/>
+        <source>Invert Color	%1</source>
+        <translation>Invertir colores	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="330"/>
+        <source>Tools</source>
+        <translation>Herramientas</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="332"/>
+        <source>Mode</source>
+        <translation>Modo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="338"/>
+        <source>Region Selection	%1</source>
+        <translation>Selección de región	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="345"/>
+        <source>Text Selection	%1</source>
+        <translation>Selección de texto	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="352"/>
+        <source>Text Highlight	%1</source>
+        <translation>Resaltado de texto	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="359"/>
+        <source>Annotate Rectangle	%1</source>
+        <translation>Anotación rectangular	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="366"/>
+        <source>Edit Annotations	%1</source>
+        <translation>Editar anotaciones	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="373"/>
+        <source>Annotate Popup	%1</source>
+        <translation>Diálogo de anotación	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="381"/>
+        <source>Visual Line Mode	%1</source>
+        <translation>Modo de línea visual	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="388"/>
+        <source>None	%1</source>
+        <translation>Ninguna	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="427"/>
+        <source>Encrypt Document	%1</source>
+        <translation>Encriptar documento	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="432"/>
+        <source>Decrypt Document	%1</source>
+        <translation>Desencriptar documento	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="437"/>
+        <source>&amp;Navigation</source>
+        <translation>&amp;Navegación</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="440"/>
+        <source>StartPage	%1</source>
+        <translation>Página de inicio	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="444"/>
+        <source>Goto Page	%1</source>
+        <translation>Ir a la página	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="448"/>
+        <source>First Page	%1</source>
+        <translation>Primera página	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="452"/>
+        <source>Previous Page	%1</source>
+        <translation>Página anterior	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="456"/>
+        <source>Next Page	%1</source>
+        <translation>Siguiente página	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="459"/>
+        <source>Last Page	%1</source>
+        <translation>Última página	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="463"/>
+        <source>Previous Location	%1</source>
+        <translation>Ubicación anterior	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="467"/>
+        <source>Next Location	%1</source>
+        <translation>Siguiente ubicación	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="470"/>
+        <source>Marks</source>
+        <translation>Marcadores</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="473"/>
+        <source>Set Mark	%1</source>
+        <translation>Añadir marcador	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="477"/>
+        <source>Goto Mark	%1</source>
+        <translation>Ir a marcador	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="481"/>
+        <source>Delete Mark	%1</source>
+        <translation>Eliminar marcador	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="485"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Ayuda</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="487"/>
+        <source>About	%1</source>
+        <translation>Acerca de	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="491"/>
+        <source>Open Tutorial File	%1</source>
+        <translation>Abrir archivo de tutorial	%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="535"/>
+        <source>There are one or more error(s) in your config file:
+%1
+
+Loading default config.</source>
+        <translation>Hay uno o más errores en tu archivo de configuración:
+%1
+
+Cargando configuración predeterminada.</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1121"/>
+        <source>%1 -&gt; %2</source>
+        <translation>%1 -&gt; %2</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1131"/>
+        <source>Shortcut conflict(s): %1</source>
+        <translation>Conflicto(s) entre atajo(s): %1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1135"/>
+        <source>Shortcut conflict(s): %1; and %2 more</source>
+        <translation>Conflicto(s) entre atajo(s): %1; y %2 más</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1178"/>
+        <source>LLM: Unknown action</source>
+        <translation>LLM: acción desconocida</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1623"/>
+        <source>Enter page number (1 to %1)</source>
+        <translation>Número de página (de 1 a %1)</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1632"/>
+        <source>Page %1 is out of range</source>
+        <translation>La página %1 está fuera del rango</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1822"/>
+        <location filename="../Lektra.cpp" line="1993"/>
+        <location filename="../Lektra.cpp" line="2111"/>
+        <location filename="../Lektra.cpp" line="2202"/>
+        <source>PDF Files</source>
+        <translation>Archivos PDF</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1822"/>
+        <location filename="../Lektra.cpp" line="1993"/>
+        <location filename="../Lektra.cpp" line="2111"/>
+        <location filename="../Lektra.cpp" line="2202"/>
+        <location filename="../Lektra.cpp" line="3482"/>
+        <source>All Files</source>
+        <translation>Todos los archivos</translation>
+    </message>
+    <message>
+        <source>PDF Files (*.pdf);;All Files (*)</source>
+        <translation type="obsolete">Archivos PDF (*.pdf);;Todos los archivos (*)</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1837"/>
+        <location filename="../Lektra.cpp" line="2008"/>
+        <location filename="../Lektra.cpp" line="4695"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1838"/>
+        <location filename="../Lektra.cpp" line="2009"/>
+        <location filename="../Lektra.cpp" line="4696"/>
+        <source>The specified file does not exist:
+%1</source>
+        <translation>El archivo no existe:
+%1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2202"/>
+        <source>Open File</source>
+        <translation>Abrir archivo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2239"/>
+        <source>Unable to find %1</source>
+        <translation>No se encontró el archivo %1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2784"/>
+        <source>File %1 has unsaved changes. Do you want to save them?</source>
+        <translation>El archivo %1 tiene cambios sin guardar. ¿Deseas guardarlos?</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2807"/>
+        <source>Confirm Quit</source>
+        <translation>Confirmar cierre</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2807"/>
+        <source>Are you sure you want to quit Lektra?</source>
+        <translation>¿Estás seguro de que quieres salir de Lektra?</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2924"/>
+        <source>Open Location</source>
+        <translation>Abrir ruta</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2926"/>
+        <source>File Properties</source>
+        <translation>Propiedades del archivo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2929"/>
+        <source>Move Tab to New Window</source>
+        <translation>Mover pestaña a una ventana nueva</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2936"/>
+        <source>Close Tab</source>
+        <translation>Cerrar pestaña</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3287"/>
+        <location filename="../Lektra.cpp" line="3295"/>
+        <source>Load Session</source>
+        <translation>Cargar sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3287"/>
+        <source>No sessions found</source>
+        <translation>No se encontraron sesiones</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3296"/>
+        <source>Session to load (existing sessions are listed): </source>
+        <translation>Sesión a cargar (se muestran las sesiones existentes): </translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3309"/>
+        <location filename="../Lektra.cpp" line="3319"/>
+        <source>Session File Parse Error</source>
+        <translation>Error al procesar el archivo de sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3312"/>
+        <source>JSON parse error:</source>
+        <translation>Error de análisis de JSON:</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3320"/>
+        <location filename="../Lektra.cpp" line="3322"/>
+        <source>Session file root is not an array</source>
+        <translation>El archivo raíz de la sesión no es un arreglo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3344"/>
+        <source>Open Session</source>
+        <translation>Abrir sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3345"/>
+        <source>Could not open session: %1</source>
+        <translation>No se pudo abrir la sesión %1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3360"/>
+        <source>Session Directory</source>
+        <translation>Directorio de sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3361"/>
+        <source>Unable to create sessions directory due to an unknown error.</source>
+        <translation>No se pudo crear el directorio de las sesiones debido a un error desconocido.</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3379"/>
+        <location filename="../Lektra.cpp" line="3397"/>
+        <location filename="../Lektra.cpp" line="3456"/>
+        <source>Save Session</source>
+        <translation>Guardar sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3380"/>
+        <source>No files in session to save the session</source>
+        <translation>No hay archivos en esta sesión para guardar</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3398"/>
+        <source>Session name cannot be empty</source>
+        <translation>El nombre de la sesión no puede estar vacío</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3408"/>
+        <location filename="../Lektra.cpp" line="3490"/>
+        <source>Overwrite Session</source>
+        <translation>Sobreescribir sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3409"/>
+        <location filename="../Lektra.cpp" line="3491"/>
+        <source>Session named &quot;%1&quot; already exists. Do you want to overwrite it?</source>
+        <translation>La sesión &quot;%1&quot; ya existe. ¿Deseas sobreescribirla?</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3457"/>
+        <source>Could not save session: %1</source>
+        <translation>No se pudo guardar la sesión: %1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3472"/>
+        <location filename="../Lektra.cpp" line="3481"/>
+        <location filename="../Lektra.cpp" line="3505"/>
+        <source>Save As Session</source>
+        <translation>Guardar como sesión</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3473"/>
+        <source>Cannot save session as you are not currently in a session</source>
+        <translation>No se pudo guardar la sesión ya que no te encuentras en una</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3482"/>
+        <source>Lektra session files</source>
+        <translation>Archivos de sesión de Lektra</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3506"/>
+        <source>Failed to save session.</source>
+        <translation>No se pudo guardar la sesión.</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3533"/>
+        <source>Startup</source>
+        <translation>Inicio</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3535"/>
+        <location filename="../Lektra.cpp" line="3544"/>
+        <source>Start Page</source>
+        <translation>Página de inicio</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3576"/>
+        <source>Copy current selection to clipboard</source>
+        <translation>Copiar selección al portapapeles</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3579"/>
+        <source>Cancel and clear current selection</source>
+        <translation>Cancelar y borrar la selección actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3581"/>
+        <source>Reselect the last text selection</source>
+        <translation>Volver a seleccionar la última selección de texto</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3586"/>
+        <source>Toggle presentation mode</source>
+        <translation>Cambiar modo de presentación</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3589"/>
+        <source>Toggle fullscreen</source>
+        <translation>Cambiar a pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3591"/>
+        <source>Open command palette</source>
+        <translation>Abrir selector de comandos</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3594"/>
+        <source>Toggle tab bar</source>
+        <translation>Mostrar u ocultar la barra de pestañas</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3596"/>
+        <source>Toggle menu bar</source>
+        <translation>Mostrar u ocultar la barra del menú</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3598"/>
+        <source>Toggle status bar</source>
+        <translation>Mostrar u ocultar la barra de estado</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3600"/>
+        <source>Toggle focus mode</source>
+        <translation>Cambiar el modo de enfoque</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3602"/>
+        <source>Toggle visual line mode</source>
+        <translation>Activar o desactivar el modo de línea visual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3607"/>
+        <source>Toggle LLM assistant widget</source>
+        <translation>Activar o desactivar el widget del asistente LLM</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3612"/>
+        <source>Open link using keyboard hint</source>
+        <translation>Abrir enlace usando el atajo de teclado</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3614"/>
+        <source>Copy link URL using keyboard hint</source>
+        <translation>Copiar enlace usando el atajo de teclado</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3618"/>
+        <source>Go to first page</source>
+        <translation>Ir a la primera página</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3620"/>
+        <source>Go to last page</source>
+        <translation>Ir a la última página</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3622"/>
+        <source>Go to next page</source>
+        <translation>Ir a la siguiente página</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3624"/>
+        <source>Go to previous page</source>
+        <translation>Retroceder a la página anterior</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3626"/>
+        <source>Jump to a specific page number</source>
+        <translation>Saltar a una página en específico</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3630"/>
+        <source>Set a named mark at current position</source>
+        <translation>Definir un marcador con nombre en esta posición</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3632"/>
+        <source>Delete a named mark</source>
+        <translation>Eliminar un marcador con nombre</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3634"/>
+        <source>Jump to a named mark</source>
+        <translation>Saltar a un marcador con nombre</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3638"/>
+        <source>Scroll down</source>
+        <translation>Desplazarse hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3640"/>
+        <source>Scroll up</source>
+        <translation>Desplazarse hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3642"/>
+        <source>Scroll left</source>
+        <translation>Desplazarse hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3644"/>
+        <source>Scroll right</source>
+        <translation>Desplazarse hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3648"/>
+        <source>Rotate page clockwise</source>
+        <translation>Girar la página en sentido horario</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3650"/>
+        <source>Rotate page counter-clockwise</source>
+        <translation>Girar la página en sentido antihorario</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3654"/>
+        <source>Go back in location history</source>
+        <translation>Retroceder en el historial</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3656"/>
+        <source>Go forward in location history</source>
+        <translation>Avanzar en el historial</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3660"/>
+        <source>Zoom in</source>
+        <translation>Acercar</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3662"/>
+        <source>Zoom out</source>
+        <translation>Alejar</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3664"/>
+        <source>Reset zoom to default</source>
+        <translation>Reiniciar el acercamiento</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3666"/>
+        <source>Set zoom to a specific level</source>
+        <translation>Acercar a un nivel específico</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3670"/>
+        <source>Split view horizontally</source>
+        <translation>Dividir vista horizontalmente</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3672"/>
+        <source>Split view vertically</source>
+        <translation>Dividir vista verticalmente</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3674"/>
+        <source>Close current split</source>
+        <translation>Cerrar el panel actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3676"/>
+        <source>Focus split to the right</source>
+        <translation>Enfocar el panel derecho</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3678"/>
+        <source>Focus split to the left</source>
+        <translation>Enfocar el panel izquierdo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3680"/>
+        <source>Focus split above</source>
+        <translation>Enfocar el panel superior</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3682"/>
+        <source>Focus split below</source>
+        <translation>Enfocar el panel inferior</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3685"/>
+        <source>Close all splits except current</source>
+        <translation>Cerrar todos los paneles excepto el actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3689"/>
+        <source>Create or focus portal</source>
+        <translation>Crear o enfocar un portal</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3694"/>
+        <source>Open file in new tab</source>
+        <translation>Abrir archivo en una pestaña nueva</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3696"/>
+        <source>Open file in vertical split</source>
+        <translation>Abrir archivo en un nuevo panel vertical</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3698"/>
+        <source>Open file in horizontal split</source>
+        <translation>Abrir archivo en un nuevo panel horizontal</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3700"/>
+        <source>Open file (do what I mean)</source>
+        <translatorcomment>[lito] what does this even mean??????</translatorcomment>
+        <translation>Abrir archivo (haz lo que te digo)</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3702"/>
+        <source>Close current file</source>
+        <translation>Cerrar el archivo actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3704"/>
+        <source>Save current file</source>
+        <translation>Guardar el archivo actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3706"/>
+        <source>Save current file as a new name</source>
+        <translation>Guardar este archivo con un nombre nuevo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3708"/>
+        <source>Encrypt current document</source>
+        <translation>Encriptar el documento actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3710"/>
+        <source>Decrypt current document</source>
+        <translation>Desencriptar el documento actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3712"/>
+        <source>Reload current file from disk</source>
+        <translation>Recargar el archivo actual desde el disco</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3714"/>
+        <source>Show file properties</source>
+        <translation>Mostrar propiedades del archivo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3716"/>
+        <source>Show recently opened files</source>
+        <translation>Mostrar archivos recientes</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3721"/>
+        <source>Toggle annotation select mode</source>
+        <translation>Cambiar el modo de selección de anotaciones</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3723"/>
+        <source>Toggle annotation popup mode</source>
+        <translation>Cambiar el modo emergente de anotaciones</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3725"/>
+        <source>Toggle rectangle annotation mode</source>
+        <translation>Cambiar el modo de anotaciones rectangulares</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3727"/>
+        <source>Toggle text highlight mode</source>
+        <translation>Cambiar modo de resaltado del texto</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3730"/>
+        <source>Toggle none interaction mode</source>
+        <translation>Cambiar modo de no interacción</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3735"/>
+        <source>Switch to text selection mode</source>
+        <translation>Cambiar a modo de selección de texto</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3738"/>
+        <source>Switch to region selection mode</source>
+        <translation>Cambiar a modo de selección de regiones</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3742"/>
+        <source>Fit page to window width</source>
+        <translation>Ajustar página al ancho de la ventana</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3744"/>
+        <source>Fit page to window height</source>
+        <translation>Ajustar página a lo largo de la ventana</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3746"/>
+        <source>Fit entire page in window</source>
+        <translation>Ajustar la página completa en la ventana</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3748"/>
+        <source>Toggle automatic resize to fit</source>
+        <translation>Cambiar modo de redimensión automática a ajuste</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3752"/>
+        <source>Save current session</source>
+        <translation>Guardar sesión actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3755"/>
+        <source>Save current session under a new name</source>
+        <translation>Guardar la sesión actual con un nombre nuevo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3757"/>
+        <source>Load a saved session</source>
+        <translation>Cargar una sesión guardada</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3761"/>
+        <source>Close all tabs to the left</source>
+        <translation>Cerrar todas las pestañas a la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3763"/>
+        <source>Close all tabs to the right</source>
+        <translation>Cerrar todas las pestañas a la derecha</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3765"/>
+        <source>Close all tabs except current</source>
+        <translation>Cerrar todas las pestañas excepto la actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3767"/>
+        <source>Move current tab right</source>
+        <translation>Mover la pestaña actual a la derecha</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3769"/>
+        <source>Move current tab left</source>
+        <translation>Mover la pestaña actual a la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3771"/>
+        <source>Switch to first tab</source>
+        <translation>Cambiar a la primera pestaña</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3773"/>
+        <source>Switch to last tab</source>
+        <translation>Cambiar a la última pestaña</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3775"/>
+        <source>Switch to next tab</source>
+        <translation>Cambiar a la pestaña siguiente</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3777"/>
+        <source>Switch to previous tab</source>
+        <translation>Cambiar a la pestaña anterior</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3779"/>
+        <source>Close current tab</source>
+        <translation>Cerrar la pestaña actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3781"/>
+        <source>Go to tab by number</source>
+        <translation>Cambiar a la última pestaña</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3783"/>
+        <source>Switch to tab 1</source>
+        <translation>Cambiar a la pestaña 1</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3785"/>
+        <source>Switch to tab 2</source>
+        <translation>Cambiar a la pestaña 2</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3787"/>
+        <source>Switch to tab 3</source>
+        <translation>Cambiar a la pestaña 3</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3789"/>
+        <source>Switch to tab 4</source>
+        <translation>Cambiar a la pestaña 4</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3791"/>
+        <source>Switch to tab 5</source>
+        <translation>Cambiar a la pestaña 5</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3793"/>
+        <source>Switch to tab 6</source>
+        <translation>Cambiar a la pestaña 6</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3795"/>
+        <source>Switch to tab 7</source>
+        <translation>Cambiar a la pestaña 7</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3797"/>
+        <source>Switch to tab 8</source>
+        <translation>Cambiar a la pestaña 8</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3799"/>
+        <source>Switch to tab 9</source>
+        <translation>Cambiar a la pestaña 9</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3803"/>
+        <source>Open document outline picker</source>
+        <translation>Abrir selector de índice del documento</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3805"/>
+        <source>Search within highlights</source>
+        <translation>Buscar dentro de los resaltados</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3812"/>
+        <source>Search document using regex</source>
+        <translation>Buscar en el documento usando expresiones regulares</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3814"/>
+        <source>Jump to next search result</source>
+        <translation>Ir al siguiente resultado de búsqueda</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3816"/>
+        <source>Jump to previous search result</source>
+        <translation>Ir al resultado anterior de búsqueda</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3818"/>
+        <source>Search with inline query argument</source>
+        <translation>Buscar con argumento en línea</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3823"/>
+        <source>Single page layout</source>
+        <translation>Disposición de una sola página</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3827"/>
+        <source>Horizontal (left to right) layout</source>
+        <translation>Disposición horizontal (de izquierda a derecha)</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3830"/>
+        <source>Vertical (top to bottom) layout</source>
+        <translation>Disposición vertical (de arriba a abajo)</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3833"/>
+        <source>Book (two page spread) layout</source>
+        <translation>Disposición tipo libro (doble página)</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3838"/>
+        <source>Set device pixel ratio</source>
+        <translation>Establecer la relación de píxeles del dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3841"/>
+        <source>Open folder containing current file</source>
+        <translation>Abrir la carpeta que contiene el archivo actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3843"/>
+        <source>Undo last action</source>
+        <translation>Deshacer la última acción</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3845"/>
+        <source>Redo last undone action</source>
+        <translation>Rehacer la última acción deshecha</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3848"/>
+        <source>Highlight current text selection</source>
+        <translation>Resaltar la selección de texto actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3850"/>
+        <source>Toggle inverted colour rendering</source>
+        <translation>Colores invertidos</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3852"/>
+        <source>Re-show the last jump marker</source>
+        <translation>Volver a mostrar el último marcador de salto</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3855"/>
+        <source>Reopen last closed file</source>
+        <translation>Volver a abrir el último archivo cerrado</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3858"/>
+        <source>Copy current page as image</source>
+        <translation>Copiar la página actual como imagen</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3861"/>
+        <source>Run debug command</source>
+        <translation>Ejecutar comando de depuración</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3866"/>
+        <source>Show startup screen</source>
+        <translation>Mostrar la pantalla de inicio</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3868"/>
+        <source>Open tutorial document</source>
+        <translation>Abrir el documento del tutorial</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3870"/>
+        <source>Show about dialog</source>
+        <translation>Mostrar el cuadro de diálogo «Acerca de»</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3885"/>
+        <source>Failed to trim recent files store</source>
+        <translation>No se pudo depurar la lista de archivos recientes</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3897"/>
+        <location filename="../Lektra.cpp" line="3902"/>
+        <source>Set DPR</source>
+        <translation>Establecer la relación de píxeles (DPR)</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3897"/>
+        <source>Enter the Device Pixel Ratio (DPR) value: </source>
+        <translation>Introducir el valor de la relación de píxeles (DPR): </translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3966"/>
+        <source>Go to Tab</source>
+        <translation>Ir a la pestaña</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3966"/>
+        <source>Enter tab number: </source>
+        <translation>Introducir número de pestaña: </translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3973"/>
+        <source>Invalid Tab Number</source>
+        <translation>Número de pestaña no válido</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4283"/>
+        <source>Select Color</source>
+        <translation>Seleccionar color</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4320"/>
+        <source>Escape key pressed handled</source>
+        <translation>Pulsación de la tecla Escape gestionada</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4364"/>
+        <source>Show Tutorial File</source>
+        <translation>Mostrar el archivo del tutorial</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4365"/>
+        <source>Not yet implemented for Mac</source>
+        <translation>Aún no implementado para Mac</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4368"/>
+        <source>Not yet implemented for Windows</source>
+        <translation>Aún no implementado para Windows</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4964"/>
+        <source>No recent files found.</source>
+        <translation>No se encontraron archivos recientes.</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5022"/>
+        <source>Reopen_last_file: file no longer exists:</source>
+        <translation>Volver a abrir el último archivo: el archivo ya no existe:</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5040"/>
+        <location filename="../Lektra.cpp" line="5044"/>
+        <source>Set Mark</source>
+        <translation>Establecer marcador</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5040"/>
+        <source>Enter mark key (a-z for local, A-Z for global):</source>
+        <translation>Introducir tecla de marcador (a-z para local, A-Z para global):</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5044"/>
+        <location filename="../Lektra.cpp" line="5068"/>
+        <location filename="../Lektra.cpp" line="5094"/>
+        <source>Mark key cannot be empty</source>
+        <translation>La tecla de marcador no puede estar vacía</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5064"/>
+        <location filename="../Lektra.cpp" line="5068"/>
+        <source>Delete Mark</source>
+        <translation>Eliminar marcador</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5064"/>
+        <source>Mark to delete:</source>
+        <translation>Marcador a eliminar:</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5090"/>
+        <location filename="../Lektra.cpp" line="5094"/>
+        <source>Goto Mark</source>
+        <translation>Ir al marcador</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5090"/>
+        <source>Mark to go to:</source>
+        <translation>Marcador al que ir:</translation>
+    </message>
+</context>
+<context>
+    <name>OutlinePicker</name>
+    <message>
+        <location filename="../OutlinePicker.cpp" line="11"/>
+        <location filename="../OutlinePicker.cpp" line="16"/>
+        <source>Title</source>
+        <translation>Título</translation>
+    </message>
+    <message>
+        <location filename="../OutlinePicker.cpp" line="12"/>
+        <source>Page</source>
+        <translation>Página</translation>
+    </message>
+</context>
+<context>
+    <name>PopupAnnotation</name>
+    <message>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="105"/>
+        <source>Delete</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="106"/>
+        <source>Comment</source>
+        <translation>Comentar</translation>
+    </message>
+</context>
+<context>
+    <name>RecentFilesModel</name>
+    <message>
+        <location filename="../RecentFilesModel.cpp" line="116"/>
+        <source>File Path</source>
+        <translation>Ruta al archivo</translation>
+    </message>
+    <message>
+        <location filename="../RecentFilesModel.cpp" line="118"/>
+        <source>Last Visited</source>
+        <translation>Última vez visitado</translation>
+    </message>
+</context>
+<context>
+    <name>RectAnnotation</name>
+    <message>
+        <location filename="../Annotations/RectAnnotation.hpp" line="85"/>
+        <source>Delete</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../Annotations/RectAnnotation.hpp" line="86"/>
+        <source>Change Color</source>
+        <translation>Cambiar color</translation>
+    </message>
+    <message>
+        <location filename="../Annotations/RectAnnotation.hpp" line="87"/>
+        <source>Comment</source>
+        <translation>Comentar</translation>
+    </message>
+</context>
+<context>
+    <name>Statusbar</name>
+    <message>
+        <location filename="../Statusbar.hpp" line="48"/>
+        <source>of</source>
+        <translation>de</translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="120"/>
+        <source>Region Selection</source>
+        <translation>Selección de región</translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="127"/>
+        <source>Text Selection</source>
+        <translation>Selección de texto</translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="134"/>
+        <source>Text Highlight</source>
+        <translation>Resaltado de texto</translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="141"/>
+        <source>Annot Select</source>
+        <translation>Selección de anotaciones</translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="148"/>
+        <source>Annot Rect</source>
+        <translation>Anotación rectangular</translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="155"/>
+        <source>Annot Popup</source>
+        <translation>Anotación emergente</translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="162"/>
+        <source>Visual Line</source>
+        <translation>Línea visual</translation>
+    </message>
+</context>
+</TS>

--- a/src/Translations/lektra.ts
+++ b/src/Translations/lektra.ts
@@ -1,0 +1,1536 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../AboutDialog.cpp" line="26"/>
+        <location filename="../AboutDialog.cpp" line="85"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="88"/>
+        <source>Libraries Used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="89"/>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="125"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../AboutDialog.cpp" line="126"/>
+        <source>Created by</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DocumentView</name>
+    <message>
+        <location filename="../DocumentView.cpp" line="532"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="533"/>
+        <source>No matches found for the given term.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3453"/>
+        <source>Add Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3453"/>
+        <source>Enter annotation comment:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3996"/>
+        <source>Save Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3997"/>
+        <source>PNG Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3998"/>
+        <source>JPEG Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3999"/>
+        <source>BMP Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4222"/>
+        <source>Add Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4222"/>
+        <source>Enter annotation text:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4456"/>
+        <source>Password Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4456"/>
+        <source>Enter password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4475"/>
+        <source>Incorrect Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="4476"/>
+        <source>The password you entered is incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditLastPagesWidget</name>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="16"/>
+        <source>Remove unfound files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="17"/>
+        <location filename="../EditLastPagesWidget.cpp" line="121"/>
+        <location filename="../EditLastPagesWidget.cpp" line="126"/>
+        <source>Revert Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="18"/>
+        <source>Delete row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="19"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="20"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="68"/>
+        <location filename="../EditLastPagesWidget.cpp" line="76"/>
+        <source>Apply Changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="68"/>
+        <source>Do you want to apply the changes ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="77"/>
+        <source>Failed to save recent files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="122"/>
+        <source>There are no changes to revert to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../EditLastPagesWidget.cpp" line="126"/>
+        <source>Do you really want to revert the changes ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>HighlightAnnotation</name>
+    <message>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="105"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="106"/>
+        <source>Change Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="107"/>
+        <source>Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Lektra</name>
+    <message>
+        <location filename="../Lektra.cpp" line="118"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="121"/>
+        <source>Open File	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="124"/>
+        <source>Open File In VSplit	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="128"/>
+        <source>Open File In HSplit	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="132"/>
+        <location filename="../Lektra.cpp" line="4963"/>
+        <source>Recent Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="135"/>
+        <source>File Properties	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="140"/>
+        <source>Open Containing Folder	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="146"/>
+        <source>Save File	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="150"/>
+        <source>Save As File	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="153"/>
+        <source>Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="156"/>
+        <source>Save	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="159"/>
+        <source>Save As	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="162"/>
+        <source>Load	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="168"/>
+        <source>Close File	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="172"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="174"/>
+        <source>&amp;Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="176"/>
+        <source>Undo	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="179"/>
+        <source>Redo	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="184"/>
+        <source>Last Pages	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="188"/>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="190"/>
+        <source>Fullscreen	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="196"/>
+        <source>Zoom In	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="199"/>
+        <source>Zoom Out	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="204"/>
+        <source>Fit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="207"/>
+        <source>Width	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="211"/>
+        <source>Height	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="215"/>
+        <source>Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="222"/>
+        <source>Auto Fit	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="231"/>
+        <source>Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="236"/>
+        <source>Single Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="240"/>
+        <source>Left to Right Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="245"/>
+        <source>Top to Bottom Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="250"/>
+        <source>Book	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="275"/>
+        <source>Show/Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="279"/>
+        <source>LLM Widget	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="286"/>
+        <source>Command Picker	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="290"/>
+        <source>Outline	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="297"/>
+        <source>Highlight Annotation Search	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="305"/>
+        <source>Menubar	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="311"/>
+        <source>Tabs	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="317"/>
+        <source>Statusbar	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="323"/>
+        <source>Invert Color	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="330"/>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="332"/>
+        <source>Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="338"/>
+        <source>Region Selection	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="345"/>
+        <source>Text Selection	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="352"/>
+        <source>Text Highlight	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="359"/>
+        <source>Annotate Rectangle	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="366"/>
+        <source>Edit Annotations	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="373"/>
+        <source>Annotate Popup	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="381"/>
+        <source>Visual Line Mode	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="388"/>
+        <source>None	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="427"/>
+        <source>Encrypt Document	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="432"/>
+        <source>Decrypt Document	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="437"/>
+        <source>&amp;Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="440"/>
+        <source>StartPage	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="444"/>
+        <source>Goto Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="448"/>
+        <source>First Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="452"/>
+        <source>Previous Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="456"/>
+        <source>Next Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="459"/>
+        <source>Last Page	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="463"/>
+        <source>Previous Location	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="467"/>
+        <source>Next Location	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="470"/>
+        <source>Marks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="473"/>
+        <source>Set Mark	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="477"/>
+        <source>Goto Mark	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="481"/>
+        <source>Delete Mark	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="485"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="487"/>
+        <source>About	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="491"/>
+        <source>Open Tutorial File	%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="535"/>
+        <source>There are one or more error(s) in your config file:
+%1
+
+Loading default config.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1121"/>
+        <source>%1 -&gt; %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1131"/>
+        <source>Shortcut conflict(s): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1135"/>
+        <source>Shortcut conflict(s): %1; and %2 more</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1178"/>
+        <source>LLM: Unknown action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1623"/>
+        <source>Enter page number (1 to %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1632"/>
+        <source>Page %1 is out of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1822"/>
+        <location filename="../Lektra.cpp" line="1993"/>
+        <location filename="../Lektra.cpp" line="2111"/>
+        <location filename="../Lektra.cpp" line="2202"/>
+        <source>PDF Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1822"/>
+        <location filename="../Lektra.cpp" line="1993"/>
+        <location filename="../Lektra.cpp" line="2111"/>
+        <location filename="../Lektra.cpp" line="2202"/>
+        <location filename="../Lektra.cpp" line="3482"/>
+        <source>All Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1837"/>
+        <location filename="../Lektra.cpp" line="2008"/>
+        <location filename="../Lektra.cpp" line="4695"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="1838"/>
+        <location filename="../Lektra.cpp" line="2009"/>
+        <location filename="../Lektra.cpp" line="4696"/>
+        <source>The specified file does not exist:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2202"/>
+        <source>Open File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2239"/>
+        <source>Unable to find %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2784"/>
+        <source>File %1 has unsaved changes. Do you want to save them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2807"/>
+        <source>Confirm Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2807"/>
+        <source>Are you sure you want to quit Lektra?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2924"/>
+        <source>Open Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2926"/>
+        <source>File Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2929"/>
+        <source>Move Tab to New Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="2936"/>
+        <source>Close Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3287"/>
+        <location filename="../Lektra.cpp" line="3295"/>
+        <source>Load Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3287"/>
+        <source>No sessions found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3296"/>
+        <source>Session to load (existing sessions are listed): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3309"/>
+        <location filename="../Lektra.cpp" line="3319"/>
+        <source>Session File Parse Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3312"/>
+        <source>JSON parse error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3320"/>
+        <location filename="../Lektra.cpp" line="3322"/>
+        <source>Session file root is not an array</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3344"/>
+        <source>Open Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3345"/>
+        <source>Could not open session: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3360"/>
+        <source>Session Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3361"/>
+        <source>Unable to create sessions directory due to an unknown error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3379"/>
+        <location filename="../Lektra.cpp" line="3397"/>
+        <location filename="../Lektra.cpp" line="3456"/>
+        <source>Save Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3380"/>
+        <source>No files in session to save the session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3398"/>
+        <source>Session name cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3408"/>
+        <location filename="../Lektra.cpp" line="3490"/>
+        <source>Overwrite Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3409"/>
+        <location filename="../Lektra.cpp" line="3491"/>
+        <source>Session named &quot;%1&quot; already exists. Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3457"/>
+        <source>Could not save session: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3472"/>
+        <location filename="../Lektra.cpp" line="3481"/>
+        <location filename="../Lektra.cpp" line="3505"/>
+        <source>Save As Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3473"/>
+        <source>Cannot save session as you are not currently in a session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3482"/>
+        <source>Lektra session files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3506"/>
+        <source>Failed to save session.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3533"/>
+        <source>Startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3535"/>
+        <location filename="../Lektra.cpp" line="3544"/>
+        <source>Start Page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3576"/>
+        <source>Copy current selection to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3579"/>
+        <source>Cancel and clear current selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3581"/>
+        <source>Reselect the last text selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3586"/>
+        <source>Toggle presentation mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3589"/>
+        <source>Toggle fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3591"/>
+        <source>Open command palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3594"/>
+        <source>Toggle tab bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3596"/>
+        <source>Toggle menu bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3598"/>
+        <source>Toggle status bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3600"/>
+        <source>Toggle focus mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3602"/>
+        <source>Toggle visual line mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3607"/>
+        <source>Toggle LLM assistant widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3612"/>
+        <source>Open link using keyboard hint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3614"/>
+        <source>Copy link URL using keyboard hint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3618"/>
+        <source>Go to first page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3620"/>
+        <source>Go to last page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3622"/>
+        <source>Go to next page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3624"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3626"/>
+        <source>Jump to a specific page number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3630"/>
+        <source>Set a named mark at current position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3632"/>
+        <source>Delete a named mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3634"/>
+        <source>Jump to a named mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3638"/>
+        <source>Scroll down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3640"/>
+        <source>Scroll up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3642"/>
+        <source>Scroll left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3644"/>
+        <source>Scroll right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3648"/>
+        <source>Rotate page clockwise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3650"/>
+        <source>Rotate page counter-clockwise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3654"/>
+        <source>Go back in location history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3656"/>
+        <source>Go forward in location history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3660"/>
+        <source>Zoom in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3662"/>
+        <source>Zoom out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3664"/>
+        <source>Reset zoom to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3666"/>
+        <source>Set zoom to a specific level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3670"/>
+        <source>Split view horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3672"/>
+        <source>Split view vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3674"/>
+        <source>Close current split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3676"/>
+        <source>Focus split to the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3678"/>
+        <source>Focus split to the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3680"/>
+        <source>Focus split above</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3682"/>
+        <source>Focus split below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3685"/>
+        <source>Close all splits except current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3689"/>
+        <source>Create or focus portal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3694"/>
+        <source>Open file in new tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3696"/>
+        <source>Open file in vertical split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3698"/>
+        <source>Open file in horizontal split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3700"/>
+        <source>Open file (do what I mean)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3702"/>
+        <source>Close current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3704"/>
+        <source>Save current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3706"/>
+        <source>Save current file as a new name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3708"/>
+        <source>Encrypt current document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3710"/>
+        <source>Decrypt current document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3712"/>
+        <source>Reload current file from disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3714"/>
+        <source>Show file properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3716"/>
+        <source>Show recently opened files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3721"/>
+        <source>Toggle annotation select mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3723"/>
+        <source>Toggle annotation popup mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3725"/>
+        <source>Toggle rectangle annotation mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3727"/>
+        <source>Toggle text highlight mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3730"/>
+        <source>Toggle none interaction mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3735"/>
+        <source>Switch to text selection mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3738"/>
+        <source>Switch to region selection mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3742"/>
+        <source>Fit page to window width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3744"/>
+        <source>Fit page to window height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3746"/>
+        <source>Fit entire page in window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3748"/>
+        <source>Toggle automatic resize to fit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3752"/>
+        <source>Save current session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3755"/>
+        <source>Save current session under a new name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3757"/>
+        <source>Load a saved session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3761"/>
+        <source>Close all tabs to the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3763"/>
+        <source>Close all tabs to the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3765"/>
+        <source>Close all tabs except current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3767"/>
+        <source>Move current tab right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3769"/>
+        <source>Move current tab left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3771"/>
+        <source>Switch to first tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3773"/>
+        <source>Switch to last tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3775"/>
+        <source>Switch to next tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3777"/>
+        <source>Switch to previous tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3779"/>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3781"/>
+        <source>Go to tab by number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3783"/>
+        <source>Switch to tab 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3785"/>
+        <source>Switch to tab 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3787"/>
+        <source>Switch to tab 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3789"/>
+        <source>Switch to tab 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3791"/>
+        <source>Switch to tab 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3793"/>
+        <source>Switch to tab 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3795"/>
+        <source>Switch to tab 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3797"/>
+        <source>Switch to tab 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3799"/>
+        <source>Switch to tab 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3803"/>
+        <source>Open document outline picker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3805"/>
+        <source>Search within highlights</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3812"/>
+        <source>Search document using regex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3814"/>
+        <source>Jump to next search result</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3816"/>
+        <source>Jump to previous search result</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3818"/>
+        <source>Search with inline query argument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3823"/>
+        <source>Single page layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3827"/>
+        <source>Horizontal (left to right) layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3830"/>
+        <source>Vertical (top to bottom) layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3833"/>
+        <source>Book (two page spread) layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3838"/>
+        <source>Set device pixel ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3841"/>
+        <source>Open folder containing current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3843"/>
+        <source>Undo last action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3845"/>
+        <source>Redo last undone action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3848"/>
+        <source>Highlight current text selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3850"/>
+        <source>Toggle inverted colour rendering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3852"/>
+        <source>Re-show the last jump marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3855"/>
+        <source>Reopen last closed file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3858"/>
+        <source>Copy current page as image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3861"/>
+        <source>Run debug command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3866"/>
+        <source>Show startup screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3868"/>
+        <source>Open tutorial document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3870"/>
+        <source>Show about dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3885"/>
+        <source>Failed to trim recent files store</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3897"/>
+        <location filename="../Lektra.cpp" line="3902"/>
+        <source>Set DPR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3897"/>
+        <source>Enter the Device Pixel Ratio (DPR) value: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3966"/>
+        <source>Go to Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3966"/>
+        <source>Enter tab number: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="3973"/>
+        <source>Invalid Tab Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4283"/>
+        <source>Select Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4320"/>
+        <source>Escape key pressed handled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4364"/>
+        <source>Show Tutorial File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4365"/>
+        <source>Not yet implemented for Mac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4368"/>
+        <source>Not yet implemented for Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4964"/>
+        <source>No recent files found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5022"/>
+        <source>Reopen_last_file: file no longer exists:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5040"/>
+        <location filename="../Lektra.cpp" line="5044"/>
+        <source>Set Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5040"/>
+        <source>Enter mark key (a-z for local, A-Z for global):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5044"/>
+        <location filename="../Lektra.cpp" line="5068"/>
+        <location filename="../Lektra.cpp" line="5094"/>
+        <source>Mark key cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5064"/>
+        <location filename="../Lektra.cpp" line="5068"/>
+        <source>Delete Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5064"/>
+        <source>Mark to delete:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5090"/>
+        <location filename="../Lektra.cpp" line="5094"/>
+        <source>Goto Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="5090"/>
+        <source>Mark to go to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OutlinePicker</name>
+    <message>
+        <location filename="../OutlinePicker.cpp" line="11"/>
+        <location filename="../OutlinePicker.cpp" line="16"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../OutlinePicker.cpp" line="12"/>
+        <source>Page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PopupAnnotation</name>
+    <message>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="105"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="106"/>
+        <source>Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RecentFilesModel</name>
+    <message>
+        <location filename="../RecentFilesModel.cpp" line="116"/>
+        <source>File Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RecentFilesModel.cpp" line="118"/>
+        <source>Last Visited</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RectAnnotation</name>
+    <message>
+        <location filename="../Annotations/RectAnnotation.hpp" line="85"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Annotations/RectAnnotation.hpp" line="86"/>
+        <source>Change Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Annotations/RectAnnotation.hpp" line="87"/>
+        <source>Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Statusbar</name>
+    <message>
+        <location filename="../Statusbar.hpp" line="48"/>
+        <source>of</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="120"/>
+        <source>Region Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="127"/>
+        <source>Text Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="134"/>
+        <source>Text Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="141"/>
+        <source>Annot Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="148"/>
+        <source>Annot Rect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="155"/>
+        <source>Annot Popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.cpp" line="162"/>
+        <source>Visual Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/src/TranslationsDir.hpp.in
+++ b/src/TranslationsDir.hpp.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define TRANSLATIONS_DIR "@TRANSLATIONS_DIR@"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,10 @@
 #include "Lektra.hpp"
 #include "argparse.hpp"
+#include "TranslationsDir.hpp"
 
 #include <QApplication>
+#include <QLocale>
+#include <QTranslator>
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/resource.h>
@@ -156,6 +159,44 @@ main(int argc, char *argv[])
         Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
     QApplication app(argc, argv);
     app.setWindowIcon(QIcon(":/resources/png/lektra.png"));
+
+    // Load correct localization file
+    QString baseDir = QStringLiteral(TRANSLATIONS_DIR);
+    QString fullLocale = QLocale::system().name();     // ex. "es_MX"
+    QString langOnly = fullLocale.left(2);             // ex: "es"
+
+    QTranslator* translator = new QTranslator(&app);
+
+    auto tryLoad = [&](const QString& localeDir) -> bool {
+        QString path = baseDir + "/" + localeDir + "/LC_MESSAGES/";
+        return translator->load("lektra", path);
+    };
+
+    // Using es_MX code for explanation
+
+    // Try full locale (es_MX)
+    if (tryLoad(fullLocale)) {
+        app.installTranslator(translator);
+    }
+    // Try language only (es)
+    else if (tryLoad(langOnly)) {
+        app.installTranslator(translator);
+    }
+    // Search for any directory beginning with es_ ...
+    else {
+        QDir dir(baseDir);
+        QStringList candidates = dir.entryList(
+            QStringList() << (langOnly + "_*"),
+            QDir::Dirs | QDir::NoDotAndDotDot
+        );
+
+        for (const QString& candidate : candidates) {
+            if (tryLoad(candidate)) {
+                app.installTranslator(translator);
+                break;
+            }
+        }
+    }
 
     Lektra d;
     d.Read_args_parser(program);


### PR DESCRIPTION
This PR adds app translations via Qt Linguist. That is, the app is now prepared to be translated to different languages!

Includes a full translation to Spanish and a template file `lektra.ts` file that can be copied for any locale `lektra.<locale>.ts` to create translations for any other language of interest.

Note for the developer: every time you update a string wrapped by tr, you will need to issue this command on the root of your project so the translation strings get refreshed:

```
lupdate src -ts src/Translations/lektra.*
```

and wrap all your next user-facing strings with tr().

If you'd like to, I could collaborate setting up Weblate so interested users can easily contribute with translations to this project via [its browser page](https://hosted.weblate.org).