### PR TITLE
Fix typo in Spanish translation for annotation comment

### DIFF
--- a/src/Translations/lektra.es.ts
+++ b/src/Translations/lektra.es.ts
@@ -58,7 +58,7 @@
     <message>
         <location filename="../DocumentView.cpp" line="3453"/>
         <source>Enter annotation comment:</source>
-        <translation>Escribir comenntario de la anotación:</translation>
+        <translation>Escribir comentario de la anotación:</translation>
     </message>
     <message>
         <location filename="../DocumentView.cpp" line="3996"/>

--- a/src/Translations/lektra.es.ts
+++ b/src/Translations/lektra.es.ts
@@ -1014,8 +1014,7 @@ Cargando configuración predeterminada.</translation>
     <message>
         <location filename="../Lektra.cpp" line="3700"/>
         <source>Open file (do what I mean)</source>
-        <translatorcomment>[lito] what does this even mean??????</translatorcomment>
-        <translation>Abrir archivo (haz lo que te digo)</translation>
+        <translation>Abrir archivo (paneles inteligentes)</translation>
     </message>
     <message>
         <location filename="../Lektra.cpp" line="3702"/>


### PR DESCRIPTION
I messed up a string while translating, this pr corrects it

Also correct the "do what I mean" translation defining as a sort of smart splitting/panels functionality that better describes your explanation